### PR TITLE
feat: bake schema version into product script stamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           restore-keys: sccache-${{ matrix.name }}-
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install test dependencies
         if: startsWith(matrix.shard, 'func-')
@@ -187,7 +187,7 @@ jobs:
           restore-keys: sccache-${{ matrix.name }}-
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Build
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           path: out/cache
           key: ${{ runner.os }}-${{ runner.arch }}-deps-${{ hashFiles('cmake/Dependencies.cmake', 'cmake/deps/*.cmake', 'cmake/templates/*', 'tools/build.py') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-deps-
 
       - name: Restore sccache cache
         uses: actions/cache/restore@v5
@@ -127,7 +128,7 @@ jobs:
 
       - name: Save sccache cache
         uses: actions/cache/save@v5
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: .sccache
           key: sccache-${{ matrix.name }}-${{ github.sha }}
@@ -176,6 +177,7 @@ jobs:
         with:
           path: out/cache
           key: ${{ runner.os }}-${{ runner.arch }}-deps-${{ hashFiles('cmake/Dependencies.cmake', 'cmake/deps/*.cmake', 'cmake/templates/*', 'tools/build.py') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-deps-
 
       - name: Restore sccache cache
         uses: actions/cache/restore@v5
@@ -219,7 +221,7 @@ jobs:
 
       - name: Save sccache cache
         uses: actions/cache/save@v5
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: .sccache
           key: sccache-${{ matrix.name }}-${{ github.sha }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,12 +152,20 @@ if(NOT _hook_ver_line)
 endif()
 string(REGEX MATCH "[0-9]+" ENVY_SHELL_HOOK_VERSION "${_hook_ver_line}")
 
+# Extract product script version from deploy.h (single source of truth)
+file(STRINGS src/deploy.h _prod_script_ver_line REGEX "kProductScriptVersion = [0-9]+")
+if(NOT _prod_script_ver_line)
+    message(FATAL_ERROR "Failed to extract kProductScriptVersion from src/deploy.h")
+endif()
+string(REGEX MATCH "[0-9]+" ENVY_PRODUCT_SCRIPT_VERSION "${_prod_script_ver_line}")
+
 # Generate embedded resource header (all platform variants unconditionally)
 embed_resources(envy_embedded_resources
     OUTPUT embedded_init_resources.h
     NORMALIZE_EOL
     DEFINES
         ENVY_HOOK_VERSION=${ENVY_SHELL_HOOK_VERSION}
+        ENVY_PRODUCT_SCRIPT_VERSION=${ENVY_PRODUCT_SCRIPT_VERSION}
     RESOURCES
         bootstrap_posix=src/resources/envy
         bootstrap_windows=src/resources/envy.bat
@@ -458,6 +466,7 @@ set(ENVY_UNIT_TEST_SOURCES
     src/phases/phase_install_tests.cpp
     src/cmds/cmd_extract_tests.cpp
     src/cmds/cmd_merge_depot_tests.cpp
+    src/deploy_tests.cpp
     src/luarc_tests.cpp
     src/cmds/cmd_lua_tests.cpp
     src/cmds/cmd_version_tests.cpp

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -859,6 +859,110 @@ PACKAGES = {{
         mtime_after = script_path.stat().st_mtime
         self.assertEqual(mtime_after, jan_1_2000, "File timestamp should be unchanged")
 
+    def test_sync_stamp_uses_schema_version_marker(self):
+        """Stamped scripts carry _ENVY_PRODUCT_SCRIPT_VERSION=N, not a release version string."""
+        product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
+
+        manifest = self.create_manifest(f"""
+PACKAGES = {{
+    {{ spec = "local.product_provider@v1", source = "{product_path}" }},
+}}
+""")
+
+        result = self.run_sync(manifest=manifest)
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+
+        bin_dir = self.test_dir / "envy-bin"
+        script_name = "tool.bat" if sys.platform == "win32" else "tool"
+        content = (bin_dir / script_name).read_text()
+        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", content)
+        self.assertIn("envy-managed", content)
+
+    def test_sync_rewrites_legacy_release_version_stamp(self):
+        """Pre-existing scripts in the old release-version stamp format get migrated."""
+        product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
+
+        manifest = self.create_manifest(f"""
+PACKAGES = {{
+    {{ spec = "local.product_provider@v1", source = "{product_path}" }},
+}}
+""")
+
+        bin_dir = self.test_dir / "envy-bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        script_name = "tool.bat" if sys.platform == "win32" else "tool"
+        script_path = bin_dir / script_name
+
+        if sys.platform == "win32":
+            legacy = "@echo off\r\nrem envy-managed 1.2.3\r\necho legacy\r\n"
+        else:
+            legacy = "#!/usr/bin/env bash\n# envy-managed 1.2.3\necho legacy\n"
+        script_path.write_text(legacy)
+
+        jan_1_2000 = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, 0))
+        os.utime(script_path, (jan_1_2000, jan_1_2000))
+
+        result = self.run_sync(manifest=manifest)
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+
+        mtime_after = script_path.stat().st_mtime
+        self.assertNotEqual(
+            mtime_after, jan_1_2000,
+            "Legacy-format script should have been rewritten, but timestamp is unchanged",
+        )
+
+        new_content = script_path.read_text()
+        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", new_content)
+        self.assertIn("envy-managed", new_content)
+        self.assertNotIn("1.2.3", new_content)
+        self.assertNotIn("legacy", new_content)
+
+    def test_sync_rewrites_script_with_mismatched_schema_version(self):
+        """A stamped script whose schema version drifts gets re-stamped on next sync."""
+        import re
+
+        product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
+
+        manifest = self.create_manifest(f"""
+PACKAGES = {{
+    {{ spec = "local.product_provider@v1", source = "{product_path}" }},
+}}
+""")
+
+        result1 = self.run_sync(manifest=manifest)
+        self.assertEqual(result1.returncode, 0, f"stderr: {result1.stderr}")
+
+        bin_dir = self.test_dir / "envy-bin"
+        script_name = "tool.bat" if sys.platform == "win32" else "tool"
+        script_path = bin_dir / script_name
+
+        canonical = script_path.read_text()
+        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", canonical)
+
+        mutated = re.sub(
+            r"_ENVY_PRODUCT_SCRIPT_VERSION=\d+",
+            "_ENVY_PRODUCT_SCRIPT_VERSION=999",
+            canonical,
+        )
+        self.assertNotEqual(canonical, mutated, "Failed to mutate version stamp")
+        script_path.write_text(mutated)
+
+        jan_1_2000 = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, 0))
+        os.utime(script_path, (jan_1_2000, jan_1_2000))
+
+        result2 = self.run_sync(manifest=manifest)
+        self.assertEqual(result2.returncode, 0, f"stderr: {result2.stderr}")
+
+        mtime_after = script_path.stat().st_mtime
+        self.assertNotEqual(
+            mtime_after, jan_1_2000,
+            "Script with mismatched schema version should have been rewritten",
+        )
+
+        restored = script_path.read_text()
+        self.assertEqual(restored, canonical)
+        self.assertNotIn("_ENVY_PRODUCT_SCRIPT_VERSION=999", restored)
+
     def test_product_script_execution_and_arg_forwarding(self):
         """Product scripts execute correctly and forward arguments."""
         # Create archive similar to other tests

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -878,6 +878,14 @@ PACKAGES = {{
         self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", content)
         self.assertIn("envy-managed", content)
 
+    def _write_legacy_stamped_script(self, script_path):
+        """Plant a script in the pre-change `# envy-managed <release-version>` format."""
+        if sys.platform == "win32":
+            legacy = "@echo off\r\nrem envy-managed 1.2.3\r\necho legacy\r\n"
+        else:
+            legacy = "#!/usr/bin/env bash\n# envy-managed 1.2.3\necho legacy\n"
+        script_path.write_text(legacy)
+
     def test_sync_rewrites_legacy_release_version_stamp(self):
         """Pre-existing scripts in the old release-version stamp format get migrated."""
         product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
@@ -893,11 +901,7 @@ PACKAGES = {{
         script_name = "tool.bat" if sys.platform == "win32" else "tool"
         script_path = bin_dir / script_name
 
-        if sys.platform == "win32":
-            legacy = "@echo off\r\nrem envy-managed 1.2.3\r\necho legacy\r\n"
-        else:
-            legacy = "#!/usr/bin/env bash\n# envy-managed 1.2.3\necho legacy\n"
-        script_path.write_text(legacy)
+        self._write_legacy_stamped_script(script_path)
 
         jan_1_2000 = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, 0))
         os.utime(script_path, (jan_1_2000, jan_1_2000))
@@ -916,6 +920,71 @@ PACKAGES = {{
         self.assertIn("envy-managed", new_content)
         self.assertNotIn("1.2.3", new_content)
         self.assertNotIn("legacy", new_content)
+
+    def test_sync_strict_accepts_legacy_envy_managed_stamp(self):
+        """Strict mode must treat legacy `# envy-managed <release-version>` as envy-owned, not as a user-owned conflict, and migrate it."""
+        product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
+
+        manifest = self.create_manifest(f"""
+PACKAGES = {{
+    {{ spec = "local.product_provider@v1", source = "{product_path}" }},
+}}
+""")
+
+        bin_dir = self.test_dir / "envy-bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        script_name = "tool.bat" if sys.platform == "win32" else "tool"
+        script_path = bin_dir / script_name
+
+        self._write_legacy_stamped_script(script_path)
+
+        result = self.run_sync(manifest=manifest, strict=True)
+
+        self.assertEqual(
+            result.returncode, 0,
+            f"Strict sync rejected a legacy envy-managed stamp as a conflict; stderr: {result.stderr}",
+        )
+        self.assertNotIn("not envy-managed", result.stderr.lower())
+
+        migrated = script_path.read_text()
+        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", migrated)
+        self.assertNotIn("1.2.3", migrated)
+        self.assertNotIn("legacy", migrated)
+
+    def test_sync_legacy_migration_settles_into_idempotence(self):
+        """After a legacy-stamp script is migrated, the next sync is a no-op (mtime unchanged)."""
+        product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
+
+        manifest = self.create_manifest(f"""
+PACKAGES = {{
+    {{ spec = "local.product_provider@v1", source = "{product_path}" }},
+}}
+""")
+
+        bin_dir = self.test_dir / "envy-bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        script_name = "tool.bat" if sys.platform == "win32" else "tool"
+        script_path = bin_dir / script_name
+
+        self._write_legacy_stamped_script(script_path)
+
+        result1 = self.run_sync(manifest=manifest)
+        self.assertEqual(result1.returncode, 0, f"stderr: {result1.stderr}")
+        migrated = script_path.read_text()
+        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", migrated)
+
+        jan_1_2000 = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, 0))
+        os.utime(script_path, (jan_1_2000, jan_1_2000))
+
+        result2 = self.run_sync(manifest=manifest)
+        self.assertEqual(result2.returncode, 0, f"stderr: {result2.stderr}")
+
+        mtime_after = script_path.stat().st_mtime
+        self.assertEqual(
+            mtime_after, jan_1_2000,
+            "Post-migration sync should be a no-op, but the script was rewritten",
+        )
+        self.assertEqual(script_path.read_text(), migrated)
 
     def test_sync_rewrites_script_with_mismatched_schema_version(self):
         """A stamped script whose schema version drifts gets re-stamped on next sync."""

--- a/src/deploy.cpp
+++ b/src/deploy.cpp
@@ -11,10 +11,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#ifndef ENVY_VERSION_STR
-#error "ENVY_VERSION_STR must be defined by the build system"
-#endif
-
 namespace envy {
 
 namespace fs = std::filesystem;
@@ -40,13 +36,6 @@ void replace_all(std::string &s, std::string_view from, std::string_view to) {
     s.replace(pos, from.length(), to);
     pos += to.length();
   }
-}
-
-std::string stamp_product_script(std::string_view product_name, platform_id platform) {
-  std::string result{ get_product_script_template(platform) };
-  replace_all(result, "@@ENVY_VERSION@@", ENVY_VERSION_STR);
-  replace_all(result, "@@PRODUCT_NAME@@", product_name);
-  return result;
 }
 
 std::string read_file_content(fs::path const &path) {
@@ -91,6 +80,13 @@ void set_product_executable(fs::path const &path, platform_id platform) {
 
 }  // namespace
 
+std::string deploy_stamp_product_script(std::string_view product_name,
+                                        platform_id platform) {
+  std::string result{ get_product_script_template(platform) };
+  replace_all(result, "@@PRODUCT_NAME@@", product_name);
+  return result;
+}
+
 void deploy_product_scripts(fs::path const &bin_dir,
                             std::vector<product_info> const &products,
                             bool strict,
@@ -128,7 +124,9 @@ void deploy_product_scripts(fs::path const &bin_dir,
         continue;
       }
 
-      std::string const new_content{ stamp_product_script(product.product_name, plat) };
+      std::string const new_content{
+        deploy_stamp_product_script(product.product_name, plat)
+      };
       std::string const existing_content{ read_file_content(script_path) };
       if (new_content == existing_content) {
         ++unchanged;

--- a/src/deploy.cpp
+++ b/src/deploy.cpp
@@ -124,9 +124,8 @@ void deploy_product_scripts(fs::path const &bin_dir,
         continue;
       }
 
-      std::string const new_content{
-        deploy_stamp_product_script(product.product_name, plat)
-      };
+      std::string const new_content{ deploy_stamp_product_script(product.product_name,
+                                                                 plat) };
       std::string const existing_content{ read_file_content(script_path) };
       if (new_content == existing_content) {
         ++unchanged;

--- a/src/deploy.h
+++ b/src/deploy.h
@@ -3,11 +3,18 @@
 #include "util.h"
 
 #include <filesystem>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace envy {
 
 struct product_info;
+
+inline constexpr int kProductScriptVersion = 1;
+
+std::string deploy_stamp_product_script(std::string_view product_name,
+                                        platform_id platform);
 
 void deploy_product_scripts(std::filesystem::path const &bin_dir,
                             std::vector<product_info> const &products,

--- a/src/deploy_tests.cpp
+++ b/src/deploy_tests.cpp
@@ -46,9 +46,8 @@ TEST_CASE("deploy: embedded Windows template has version baked at build time") {
 }
 
 TEST_CASE("deploy: stamp_product_script substitutes product name on POSIX") {
-  std::string const stamped{
-    envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX)
-  };
+  std::string const stamped{ envy::deploy_stamp_product_script("foo",
+                                                               envy::platform_id::POSIX) };
   CHECK(stamped.find("foo") != std::string::npos);
   CHECK(stamped.find("@@PRODUCT_NAME@@") == std::string::npos);
   CHECK(stamped.find("envy-managed") != std::string::npos);
@@ -66,14 +65,18 @@ TEST_CASE("deploy: stamp_product_script substitutes product name on Windows") {
 }
 
 TEST_CASE("deploy: stamp_product_script is deterministic") {
-  std::string const a{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
-  std::string const b{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
+  std::string const a{ envy::deploy_stamp_product_script("foo",
+                                                         envy::platform_id::POSIX) };
+  std::string const b{ envy::deploy_stamp_product_script("foo",
+                                                         envy::platform_id::POSIX) };
   CHECK(a == b);
 }
 
 TEST_CASE("deploy: stamp_product_script differs by product name") {
-  std::string const foo{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
-  std::string const bar{ envy::deploy_stamp_product_script("bar", envy::platform_id::POSIX) };
+  std::string const foo{ envy::deploy_stamp_product_script("foo",
+                                                           envy::platform_id::POSIX) };
+  std::string const bar{ envy::deploy_stamp_product_script("bar",
+                                                           envy::platform_id::POSIX) };
   CHECK(foo != bar);
   CHECK(foo.find("foo") != std::string::npos);
   CHECK(foo.find("bar") == std::string::npos);
@@ -82,8 +85,10 @@ TEST_CASE("deploy: stamp_product_script differs by product name") {
 }
 
 TEST_CASE("deploy: stamp_product_script differs by platform") {
-  std::string const posix{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
-  std::string const win{ envy::deploy_stamp_product_script("foo", envy::platform_id::WINDOWS) };
+  std::string const posix{ envy::deploy_stamp_product_script("foo",
+                                                             envy::platform_id::POSIX) };
+  std::string const win{ envy::deploy_stamp_product_script("foo",
+                                                           envy::platform_id::WINDOWS) };
   CHECK(posix != win);
   CHECK(posix.find("#!/usr/bin/env bash") != std::string::npos);
   CHECK(win.find("@echo off") != std::string::npos);

--- a/src/deploy_tests.cpp
+++ b/src/deploy_tests.cpp
@@ -1,0 +1,90 @@
+#include "deploy.h"
+
+#include "doctest.h"
+#include "embedded_init_resources.h"
+#include "platform.h"
+
+#include <string>
+#include <string_view>
+
+namespace {
+
+std::string_view embedded_posix_template() {
+  return { reinterpret_cast<char const *>(envy::embedded::kProductScriptPosix),
+           envy::embedded::kProductScriptPosixSize };
+}
+
+std::string_view embedded_windows_template() {
+  return { reinterpret_cast<char const *>(envy::embedded::kProductScriptWindows),
+           envy::embedded::kProductScriptWindowsSize };
+}
+
+}  // namespace
+
+TEST_CASE("deploy: kProductScriptVersion is positive") {
+  CHECK(envy::kProductScriptVersion > 0);
+}
+
+TEST_CASE("deploy: embedded POSIX template has version baked at build time") {
+  std::string_view const tmpl{ embedded_posix_template() };
+  std::string const expected_marker{ "_ENVY_PRODUCT_SCRIPT_VERSION=" +
+                                     std::to_string(envy::kProductScriptVersion) };
+  CHECK(tmpl.find(expected_marker) != std::string_view::npos);
+  CHECK(tmpl.find("@@ENVY_PRODUCT_SCRIPT_VERSION@@") == std::string_view::npos);
+  CHECK(tmpl.find("@@ENVY_VERSION@@") == std::string_view::npos);
+  CHECK(tmpl.find("envy-managed") != std::string_view::npos);
+}
+
+TEST_CASE("deploy: embedded Windows template has version baked at build time") {
+  std::string_view const tmpl{ embedded_windows_template() };
+  std::string const expected_marker{ "_ENVY_PRODUCT_SCRIPT_VERSION=" +
+                                     std::to_string(envy::kProductScriptVersion) };
+  CHECK(tmpl.find(expected_marker) != std::string_view::npos);
+  CHECK(tmpl.find("@@ENVY_PRODUCT_SCRIPT_VERSION@@") == std::string_view::npos);
+  CHECK(tmpl.find("@@ENVY_VERSION@@") == std::string_view::npos);
+  CHECK(tmpl.find("envy-managed") != std::string_view::npos);
+}
+
+TEST_CASE("deploy: stamp_product_script substitutes product name on POSIX") {
+  std::string const stamped{
+    envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX)
+  };
+  CHECK(stamped.find("foo") != std::string::npos);
+  CHECK(stamped.find("@@PRODUCT_NAME@@") == std::string::npos);
+  CHECK(stamped.find("envy-managed") != std::string::npos);
+  CHECK(stamped.find("_ENVY_PRODUCT_SCRIPT_VERSION=") != std::string::npos);
+}
+
+TEST_CASE("deploy: stamp_product_script substitutes product name on Windows") {
+  std::string const stamped{
+    envy::deploy_stamp_product_script("foo", envy::platform_id::WINDOWS)
+  };
+  CHECK(stamped.find("foo") != std::string::npos);
+  CHECK(stamped.find("@@PRODUCT_NAME@@") == std::string::npos);
+  CHECK(stamped.find("envy-managed") != std::string::npos);
+  CHECK(stamped.find("_ENVY_PRODUCT_SCRIPT_VERSION=") != std::string::npos);
+}
+
+TEST_CASE("deploy: stamp_product_script is deterministic") {
+  std::string const a{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
+  std::string const b{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
+  CHECK(a == b);
+}
+
+TEST_CASE("deploy: stamp_product_script differs by product name") {
+  std::string const foo{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
+  std::string const bar{ envy::deploy_stamp_product_script("bar", envy::platform_id::POSIX) };
+  CHECK(foo != bar);
+  CHECK(foo.find("foo") != std::string::npos);
+  CHECK(foo.find("bar") == std::string::npos);
+  CHECK(bar.find("bar") != std::string::npos);
+  CHECK(bar.find("foo") == std::string::npos);
+}
+
+TEST_CASE("deploy: stamp_product_script differs by platform") {
+  std::string const posix{ envy::deploy_stamp_product_script("foo", envy::platform_id::POSIX) };
+  std::string const win{ envy::deploy_stamp_product_script("foo", envy::platform_id::WINDOWS) };
+  CHECK(posix != win);
+  CHECK(posix.find("#!/usr/bin/env bash") != std::string::npos);
+  CHECK(win.find("@echo off") != std::string::npos);
+}

--- a/src/resources/product_script
+++ b/src/resources/product_script
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# envy-managed @@ENVY_VERSION@@
+# envy-managed _ENVY_PRODUCT_SCRIPT_VERSION=@@ENVY_PRODUCT_SCRIPT_VERSION@@
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 exec "$("$SCRIPT_DIR/envy" product "@@PRODUCT_NAME@@")" "$@"

--- a/src/resources/product_script.bat
+++ b/src/resources/product_script.bat
@@ -1,5 +1,5 @@
 @echo off
-rem envy-managed @@ENVY_VERSION@@
+rem envy-managed _ENVY_PRODUCT_SCRIPT_VERSION=@@ENVY_PRODUCT_SCRIPT_VERSION@@
 for /f "delims=" %%i in ('call "%~dp0envy.bat" product "@@PRODUCT_NAME@@"') do set "PRODUCT_PATH=%%i"
 if not defined PRODUCT_PATH (
     echo envy: failed to resolve product '@@PRODUCT_NAME@@' 1>&2


### PR DESCRIPTION
## Summary

- Replaces the envy release version in stamped product scripts with a per-template schema version (`kProductScriptVersion` in `src/deploy.h`), baked at build time via the existing `embed_resources` `DEFINES` mechanism — same pattern as `kShellHookVersion`.
- Removes the rewrite-every-release churn from `envy sync`: the byte-equal short-circuit in `deploy_product_scripts` now stays true across release bumps, so scripts are only rewritten when the template content actually changes. Legacy release-version stamps are auto-migrated on the next sync (byte-compare detects the drift).
- Bump `kProductScriptVersion` only when the template content changes incompatibly. Renamed the now-public helper to `deploy_stamp_product_script` per project convention.

## Test plan

- [x] `./build.sh` clean — unit tests pass (1035 cases / 3474 assertions); 8 new cases in `src/deploy_tests.cpp` cover the build-time substitution round trip (catches CMake regex / DEFINES misconfiguration), stamp determinism, product-name and platform discrimination.
- [x] `python3.13 -m functional_tests` clean (896 tests, 63 pre-existing skips) — three new tests in `test_sync.py` cover the new `_ENVY_PRODUCT_SCRIPT_VERSION=` marker, migration of legacy `# envy-managed 1.2.3` stamps, and re-stamping when the on-disk schema version drifts; the pre-existing `test_sync_timestamp_preserved_when_content_unchanged` keeps passing (now stable across release bumps, not just same-binary syncs).
- [x] Manually decoded the embedded resource blob — both POSIX and Windows templates carry `_ENVY_PRODUCT_SCRIPT_VERSION=1` on line 2 with `@@PRODUCT_NAME@@` as the only remaining runtime placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)