### PR TITLE
fix: silence zsh shell hook variable leak on cd into subproject

### DIFF
--- a/src/resources/shell_hook.zsh
+++ b/src/resources/shell_hook.zsh
@@ -25,8 +25,10 @@ _envy_find_manifest() {
   while [ "$d" != / ]; do
     if [ -f "$d/envy.lua" ]; then
       local is_root="true"
-      # Pure zsh read+regex instead of head|grep — avoids fork/exec per directory
-      local line i=0
+      # Pure zsh read+regex instead of head|grep — avoids fork/exec per directory.
+      # `line=""` is explicit: without it, zsh's NO_TYPESET_SILENT default makes
+      # `local line` print the prior iteration's value when re-declared in-loop.
+      local line="" i=0
       while (( i++ < 20 )) && IFS= read -r line; do
         if [[ "$line" =~ '^--[[:space:]]*@envy[[:space:]]+root[[:space:]]+"false"' ]]; then
           is_root="false"

--- a/src/shell_hooks.h
+++ b/src/shell_hooks.h
@@ -5,7 +5,7 @@
 
 namespace envy::shell_hooks {
 
-inline constexpr int kShellHookVersion = 9;
+inline constexpr int kShellHookVersion = 10;
 
 // Parse _ENVY_HOOK_VERSION from the first 5 lines of a hook file.
 // Returns 0 if file is missing, unreadable, or has no valid stamp.


### PR DESCRIPTION
## Summary
- Fix `line='-- @envy root "false"'` leak printed by the zsh hook when `cd`-ing from an envy root project into a nested envy subproject.
- Root cause: zsh's `NO_TYPESET_SILENT` default makes `local line i=0` print the prior iteration's value when re-declared inside the outer manifest-walk loop. Previous fix (#289) misdiagnosed this as xtrace pollution.
- Explicit `local line="" i=0` suppresses the print; `kShellHookVersion` bumped 9 → 10 so installed copies auto-refresh.

## Test plan
- [x] `./build.sh` — unit tests pass
- [x] `python3.13 -m functional_tests test_shell_hook test_shell_setup` — pass
- [x] Manual repro: `cd` from envy root project into nested subproject is now silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)