### PR TITLE
stamp product scripts with manifest-style `schema "N"` comment

### DIFF
--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -860,7 +860,7 @@ PACKAGES = {{
         self.assertEqual(mtime_after, jan_1_2000, "File timestamp should be unchanged")
 
     def test_sync_stamp_uses_schema_version_marker(self):
-        """Stamped scripts carry _ENVY_PRODUCT_SCRIPT_VERSION=N, not a release version string."""
+        """Stamped scripts carry `envy-managed schema "N"`, not a release version string."""
         product_path = self.write_spec("product_provider", SPEC_PRODUCT_PROVIDER)
 
         manifest = self.create_manifest(f"""
@@ -875,8 +875,7 @@ PACKAGES = {{
         bin_dir = self.test_dir / "envy-bin"
         script_name = "tool.bat" if sys.platform == "win32" else "tool"
         content = (bin_dir / script_name).read_text()
-        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", content)
-        self.assertIn("envy-managed", content)
+        self.assertIn("envy-managed schema \"", content)
 
     def _write_legacy_stamped_script(self, script_path):
         """Plant a script in the pre-change `# envy-managed <release-version>` format."""
@@ -916,8 +915,7 @@ PACKAGES = {{
         )
 
         new_content = script_path.read_text()
-        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", new_content)
-        self.assertIn("envy-managed", new_content)
+        self.assertIn("envy-managed schema \"", new_content)
         self.assertNotIn("1.2.3", new_content)
         self.assertNotIn("legacy", new_content)
 
@@ -947,7 +945,7 @@ PACKAGES = {{
         self.assertNotIn("not envy-managed", result.stderr.lower())
 
         migrated = script_path.read_text()
-        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", migrated)
+        self.assertIn("envy-managed schema \"", migrated)
         self.assertNotIn("1.2.3", migrated)
         self.assertNotIn("legacy", migrated)
 
@@ -971,7 +969,7 @@ PACKAGES = {{
         result1 = self.run_sync(manifest=manifest)
         self.assertEqual(result1.returncode, 0, f"stderr: {result1.stderr}")
         migrated = script_path.read_text()
-        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", migrated)
+        self.assertIn("envy-managed schema \"", migrated)
 
         jan_1_2000 = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, 0))
         os.utime(script_path, (jan_1_2000, jan_1_2000))
@@ -1006,11 +1004,11 @@ PACKAGES = {{
         script_path = bin_dir / script_name
 
         canonical = script_path.read_text()
-        self.assertIn("_ENVY_PRODUCT_SCRIPT_VERSION=", canonical)
+        self.assertIn("envy-managed schema \"", canonical)
 
         mutated = re.sub(
-            r"_ENVY_PRODUCT_SCRIPT_VERSION=\d+",
-            "_ENVY_PRODUCT_SCRIPT_VERSION=999",
+            r'schema "\d+"',
+            'schema "999"',
             canonical,
         )
         self.assertNotEqual(canonical, mutated, "Failed to mutate version stamp")
@@ -1030,7 +1028,7 @@ PACKAGES = {{
 
         restored = script_path.read_text()
         self.assertEqual(restored, canonical)
-        self.assertNotIn("_ENVY_PRODUCT_SCRIPT_VERSION=999", restored)
+        self.assertNotIn('schema "999"', restored)
 
     def test_product_script_execution_and_arg_forwarding(self):
         """Product scripts execute correctly and forward arguments."""

--- a/src/deploy_tests.cpp
+++ b/src/deploy_tests.cpp
@@ -27,8 +27,8 @@ TEST_CASE("deploy: kProductScriptVersion is positive") {
 
 TEST_CASE("deploy: embedded POSIX template has version baked at build time") {
   std::string_view const tmpl{ embedded_posix_template() };
-  std::string const expected_marker{ "_ENVY_PRODUCT_SCRIPT_VERSION=" +
-                                     std::to_string(envy::kProductScriptVersion) };
+  std::string const expected_marker{ "schema \"" +
+                                     std::to_string(envy::kProductScriptVersion) + "\"" };
   CHECK(tmpl.find(expected_marker) != std::string_view::npos);
   CHECK(tmpl.find("@@ENVY_PRODUCT_SCRIPT_VERSION@@") == std::string_view::npos);
   CHECK(tmpl.find("@@ENVY_VERSION@@") == std::string_view::npos);
@@ -37,8 +37,8 @@ TEST_CASE("deploy: embedded POSIX template has version baked at build time") {
 
 TEST_CASE("deploy: embedded Windows template has version baked at build time") {
   std::string_view const tmpl{ embedded_windows_template() };
-  std::string const expected_marker{ "_ENVY_PRODUCT_SCRIPT_VERSION=" +
-                                     std::to_string(envy::kProductScriptVersion) };
+  std::string const expected_marker{ "schema \"" +
+                                     std::to_string(envy::kProductScriptVersion) + "\"" };
   CHECK(tmpl.find(expected_marker) != std::string_view::npos);
   CHECK(tmpl.find("@@ENVY_PRODUCT_SCRIPT_VERSION@@") == std::string_view::npos);
   CHECK(tmpl.find("@@ENVY_VERSION@@") == std::string_view::npos);
@@ -51,7 +51,7 @@ TEST_CASE("deploy: stamp_product_script substitutes product name on POSIX") {
   CHECK(stamped.find("foo") != std::string::npos);
   CHECK(stamped.find("@@PRODUCT_NAME@@") == std::string::npos);
   CHECK(stamped.find("envy-managed") != std::string::npos);
-  CHECK(stamped.find("_ENVY_PRODUCT_SCRIPT_VERSION=") != std::string::npos);
+  CHECK(stamped.find("schema \"") != std::string::npos);
 }
 
 TEST_CASE("deploy: stamp_product_script substitutes product name on Windows") {
@@ -61,7 +61,7 @@ TEST_CASE("deploy: stamp_product_script substitutes product name on Windows") {
   CHECK(stamped.find("foo") != std::string::npos);
   CHECK(stamped.find("@@PRODUCT_NAME@@") == std::string::npos);
   CHECK(stamped.find("envy-managed") != std::string::npos);
-  CHECK(stamped.find("_ENVY_PRODUCT_SCRIPT_VERSION=") != std::string::npos);
+  CHECK(stamped.find("schema \"") != std::string::npos);
 }
 
 TEST_CASE("deploy: stamp_product_script is deterministic") {

--- a/src/resources/product_script
+++ b/src/resources/product_script
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# envy-managed _ENVY_PRODUCT_SCRIPT_VERSION=@@ENVY_PRODUCT_SCRIPT_VERSION@@
+# envy-managed schema "@@ENVY_PRODUCT_SCRIPT_VERSION@@"
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 exec "$("$SCRIPT_DIR/envy" product "@@PRODUCT_NAME@@")" "$@"

--- a/src/resources/product_script.bat
+++ b/src/resources/product_script.bat
@@ -1,5 +1,5 @@
 @echo off
-rem envy-managed _ENVY_PRODUCT_SCRIPT_VERSION=@@ENVY_PRODUCT_SCRIPT_VERSION@@
+rem envy-managed schema "@@ENVY_PRODUCT_SCRIPT_VERSION@@"
 for /f "delims=" %%i in ('call "%~dp0envy.bat" product "@@PRODUCT_NAME@@"') do set "PRODUCT_PATH=%%i"
 if not defined PRODUCT_PATH (
     echo envy: failed to resolve product '@@PRODUCT_NAME@@' 1>&2


### PR DESCRIPTION
## Summary
- Product script stamps switch from `envy-managed _ENVY_PRODUCT_SCRIPT_VERSION=N` to `envy-managed schema "N"`, matching the manifest's `-- @envy schema "1"` convention
- Unit and functional test assertions/mutation regex updated to match
- No backwards-compat shim for the unreleased `_ENVY_PRODUCT_SCRIPT_VERSION=N` format; legacy `# envy-managed <release-version>` migration still works via marker-based detection

## Test plan
- [x] `./build.sh` — 1035/1035 unit tests pass
- [x] `python3.13 -m functional_tests test_sync` — 898 tests pass (63 platform-skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)