### PR TITLE
build: upgrade doctest to v2.5.2

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -104,6 +104,10 @@ set(ENVY_PICOJSON_SHA256 5ddf7276d04926da7be243e7af49258e78cc27278ee9097ba45b942
 set(ENVY_PICOJSON_LICENSE_URL "https://raw.githubusercontent.com/kazuho/picojson/v${ENVY_PICOJSON_VERSION}/LICENSE")
 set(ENVY_PICOJSON_LICENSE_SHA256 5585fe141cc7bb08c953f3859db608852968d0bbc625b9b6d95c0bd6349bacb6)
 
+set(ENVY_DOCTEST_VERSION "2.5.2")
+set(ENVY_DOCTEST_URL "https://raw.githubusercontent.com/doctest/doctest/v${ENVY_DOCTEST_VERSION}/doctest/doctest.h")
+set(ENVY_DOCTEST_SHA256 1f2978b948f5958d5b6ee8dc16d8284317715d6e4fafb47956b1578198d19f66)
+
 set(PLATFORM_NETWORK_LIBS)
 if(WIN32)
     set(PLATFORM_NETWORK_LIBS ws2_32 dnsapi iphlpapi advapi32 crypt32 wldap32 winhttp bcrypt wininet)

--- a/cmake/deps/Doctest.cmake
+++ b/cmake/deps/Doctest.cmake
@@ -6,6 +6,16 @@ file(MAKE_DIRECTORY "${DOCTEST_CACHE_DIR}")
 
 set(_doctest_local_file "${DOCTEST_CACHE_DIR}/doctest.h")
 
+# Hash-verify any cached copy so a stale header from a previous version
+# (e.g. restored via CI's `restore-keys` fallback) is replaced instead of reused.
+if(EXISTS "${_doctest_local_file}")
+  file(SHA256 "${_doctest_local_file}" _doctest_cached_hash)
+  if(NOT _doctest_cached_hash STREQUAL ENVY_DOCTEST_SHA256)
+    file(REMOVE "${_doctest_local_file}")
+  endif()
+  unset(_doctest_cached_hash)
+endif()
+
 if(NOT EXISTS "${_doctest_local_file}")
   message(STATUS "Downloading doctest ${ENVY_DOCTEST_VERSION}...")
   file(DOWNLOAD

--- a/cmake/deps/Doctest.cmake
+++ b/cmake/deps/Doctest.cmake
@@ -1,33 +1,28 @@
 # Doctest - C++ testing framework (single-header amalgamation)
 # https://github.com/doctest/doctest
 
-set(DOCTEST_VERSION "2.4.12")
-set(DOCTEST_URL "https://github.com/doctest/doctest/releases/download/v${DOCTEST_VERSION}/doctest.h")
-set(DOCTEST_SHA256 "2a31654ead2a6e5ef93086ca97659b701710c80275207b3bdb12676c012daceb")
 set(DOCTEST_CACHE_DIR "${ENVY_CACHE_DIR}/doctest-src")
-
-# Ensure cache directory exists
 file(MAKE_DIRECTORY "${DOCTEST_CACHE_DIR}")
 
-set(DOCTEST_HEADER_PATH "${DOCTEST_CACHE_DIR}/doctest.h")
+set(_doctest_local_file "${DOCTEST_CACHE_DIR}/doctest.h")
 
-# Download if not cached
-if(NOT EXISTS "${DOCTEST_HEADER_PATH}")
-  message(STATUS "Downloading doctest ${DOCTEST_VERSION}...")
+if(NOT EXISTS "${_doctest_local_file}")
+  message(STATUS "Downloading doctest ${ENVY_DOCTEST_VERSION}...")
   file(DOWNLOAD
-    "${DOCTEST_URL}"
-    "${DOCTEST_HEADER_PATH}"
-    EXPECTED_HASH SHA256=${DOCTEST_SHA256}
+    "${ENVY_DOCTEST_URL}"
+    "${_doctest_local_file}"
+    EXPECTED_HASH SHA256=${ENVY_DOCTEST_SHA256}
     SHOW_PROGRESS
   )
-  message(STATUS "Doctest cached at ${DOCTEST_HEADER_PATH}")
+  message(STATUS "Doctest cached at ${_doctest_local_file}")
 else()
-  message(STATUS "Using cached doctest at ${DOCTEST_HEADER_PATH}")
+  message(STATUS "Using cached doctest at ${_doctest_local_file}")
 endif()
 
-# Create interface library
-add_library(doctest INTERFACE)
-target_include_directories(doctest INTERFACE "${DOCTEST_CACHE_DIR}")
+if(NOT TARGET doctest::doctest)
+  add_library(doctest INTERFACE)
+  target_include_directories(doctest INTERFACE "${DOCTEST_CACHE_DIR}")
+  add_library(doctest::doctest ALIAS doctest)
+endif()
 
-# Export for consumers
-add_library(doctest::doctest ALIAS doctest)
+unset(_doctest_local_file)


### PR DESCRIPTION
## Summary
- Bumps the bundled doctest single-header from 2.4.12 to 2.5.2. The v2.5.x releases switched the official asset to a full source tarball, so this pulls the amalgamated `doctest.h` directly from the v2.5.2 git tag (byte-identical to the one inside the tarball).
- Moves the doctest version/URL/hash into the central `cmake/Dependencies.cmake` catalog to match the convention used by the other single-header deps (CLI11, Picojson, Semver).
- Audited compiler warning suppressions while in the neighborhood: nothing currently disabled is there to placate doctest — all `-Wno-*` / `/wd*` flags target libgit2, libssh2, or the AWS SDK, so no cleanup needed.

## Test plan
- [x] `./build.sh` clean (no new warnings)
- [x] Unit tests pass: `[doctest] doctest version is "2.5.2"` — 1035/1035 cases, 3474/3474 assertions