### PR TITLE
feat: introduce explicit `USER_MANAGED` top-level

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,17 +165,18 @@ Specs define verbs describing how to acquire, validate, and install packages:
 
 ### User-Managed vs Cache-Managed Packages
 
-Envy supports two package models distinguished by CHECK verb presence:
+Specs declare their mode via top-level `USER_MANAGED` (boolean or function-returning-boolean; defaults to `false`). The value is resolved once at spec load and determines `p->type` for the rest of the pipeline; `CHECK` is just a phase verb.
 
-**Cache-Managed Packages** (no CHECK verb):
-- Artifacts stored in cache—hash-based lookup via `cache::ensure_asset()`
+**Cache-Managed Packages** (`USER_MANAGED = false` or absent):
+- Artifacts stored in cache—hash-based lookup via `cache::ensure_pkg()`
 - Install writes to `install_dir`; on successful return, envy auto-marks complete
-- Lock destructor renames `install/` → `asset/`, touches `envy-complete`
-- Subsequent runs: cache hit (asset exists) skips all phases
+- Lock destructor renames `install/` → `pkg/`, touches `envy-complete`
+- Subsequent runs: cache hit skips all phases
 - Full pipeline: FETCH → STAGE → BUILD → INSTALL
+- **`CHECK` is forbidden**—use `USER_MANAGED=true` if you need it
 - Example: toolchains, libraries, build tools
 
-**User-Managed Packages** (CHECK verb present):
+**User-Managed Packages** (`USER_MANAGED = true`):
 - Artifacts live outside cache (system state, environment, user directories)
 - CHECK verb tests satisfaction (string command or function returning bool)
 - Lock marked user-managed via `lock->mark_user_managed()`—destructor purges entire `entry_dir` (ephemeral workspace)
@@ -195,15 +196,17 @@ Coordinates concurrent processes, prevents duplicate work:
 Race example: Process A checks (false), waits for lock. Process B holds lock, installs Python via brew. B releases. A acquires lock, re-checks (true—Python now installed), releases, skips phases.
 
 **Implementation mechanics:**
-- Detection: `recipe_has_check_verb(r, lua)` → user vs cache path in `run_check_phase()`
-- User-managed lock: `phase_check.cpp` calls `lock->mark_user_managed()`
-- Lock destructor: `if (user_managed_) { purge_entry_dir(); }` vs `if (completed_) { rename_install_to_asset(); }`
-- Validation: `phase_recipe_fetch.cpp` rejects FETCH/STAGE/BUILD verbs when CHECK present
+- Resolution: `resolve_user_managed()` reads `USER_MANAGED` once during `phase_spec_fetch`; sets `p->type`. Function form is called with no args and must return a boolean.
+- Dispatch: `run_check_phase()` and `run_install_phase()` branch on `p->type == pkg_type::USER_MANAGED`.
+- User-managed lock: `phase_check.cpp` calls `lock->mark_user_managed()` on lock acquisition.
+- Lock destructor: `if (user_managed_) { purge_entry_dir(); }` vs `if (completed_) { rename_install_to_pkg(); }`
+- Validation: `phase_spec_fetch.cpp::validate_phases()` enforces the rules table above; `CHECK` is rejected when `USER_MANAGED` is not true; `FETCH/STAGE/BUILD` are rejected when it is.
 
 **Example: System Package Wrapper**
 ```lua
 -- python.interpreter@v3 (user-managed)
 IDENTITY = "python.interpreter@v3"
+USER_MANAGED = true
 
 -- Check if Python already installed
 CHECK = function(project_root, options)

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -76,13 +76,13 @@ This uses the same locking strategy as recipe/asset installation (see Locking & 
 - Crash recovery: next locker deletes stale `install/`, recreates `work/`, preserves `fetch/` for per-file cache reuse.
 
 ### User-Managed Packages (Ephemeral Cache)
-- Identified by presence of check verb in recipe
+- Spec declares `USER_MANAGED = true` (boolean or function-returning-boolean); resolved once during `phase_spec_fetch`
 - Lock calls `mark_user_managed()` to signal ephemeral workspace
 - Workspace created same as cache-managed: `install/`, `fetch/`, `work/` directories
-- Spec can use all phases (fetch/stage/build/install) for workspace operations
+- User-managed specs may only define `CHECK` and `INSTALL`—not FETCH/STAGE/BUILD
 - Install phase modifies system; workspace never persists to cache
 - On completion (lock destructor detects `user_managed_` flag):
-  - Entire `entry_dir` deleted (no `asset/` rename)
+  - Entire `entry_dir` deleted (no `pkg/` rename)
   - Cache entry fully purged—no persistent artifacts
   - Lock file deleted
 - Subsequent runs use check verb (not cache marker) to skip work
@@ -149,4 +149,4 @@ The `scoped_entry_lock` destructor handles three distinct completion modes:
 
 3. **Concurrent install**: Process A checks (false) → acquires lock, marks user-managed, re-checks (false) → starts install. Process B checks (false) → blocks on lock. Process A completes install, destructor purges entry. Process B acquires lock, marks user-managed, re-checks (NOW true, A finished) → releases lock immediately without running phases.
 
-4. **User-managed with fetch**: check=false → lock acquired → fetch downloads files to `fetch/` → stage extracts to `work/stage/` → install runs system command → destructor purges ALL directories (fetch/, work/, install/) → no artifacts remain.
+4. **User-managed install only**: user-managed specs are limited to `CHECK` and `INSTALL`; FETCH/STAGE/BUILD are rejected at spec load. The install runs against `project_root` and modifies system state; destructor purges the entry_dir, leaving no artifacts.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -143,7 +143,7 @@ The `scoped_entry_lock` destructor handles three distinct completion modes:
 
 ### User-Managed Package Install
 
-1. **First install with check=false**: check verb returns false (not satisfied) → lock acquired, `mark_user_managed()` called → double-check returns false → fetch/stage/build/install phases run → install modifies system (brew install, file writes, etc.) → lock destructor detects `user_managed_` flag → entire `entry_dir` deleted (fetch/, work/, install/ all purged) → lock released.
+1. **First install with check=false**: check verb returns false (not satisfied) → lock acquired, `mark_user_managed()` called → double-check returns false → install phase runs against `project_root` and modifies system (brew install, file writes, etc.; FETCH/STAGE/BUILD are rejected at spec load for user-managed specs) → lock destructor detects `user_managed_` flag → entire `entry_dir` deleted → lock released.
 
 2. **Second run with check=true**: check verb returns true (already satisfied) → no lock acquired → all phases skipped.
 

--- a/examples/local.apt@r0.lua
+++ b/examples/local.apt@r0.lua
@@ -1,6 +1,7 @@
 -- @envy schema "1"
 IDENTITY = "local.apt@r0"
 PLATFORMS = { "linux" }
+USER_MANAGED = true
 
 local missing_packages = {}
 

--- a/examples/local.brew@r0.lua
+++ b/examples/local.brew@r0.lua
@@ -1,6 +1,7 @@
 -- @envy schema "1"
 IDENTITY = "local.brew@r0"
 PLATFORMS = { "darwin" }
+USER_MANAGED = true
 
 CHECK = "brew --version"
 

--- a/examples/local.brew_package@r0.lua
+++ b/examples/local.brew_package@r0.lua
@@ -1,6 +1,7 @@
 -- @envy schema "1"
 IDENTITY = "local.brew_package@r0"
 PLATFORMS = { "darwin" }
+USER_MANAGED = true
 
 DEPENDENCIES = { spec = "local.brew@r0", source = "local.brew@r0.lua" }
 

--- a/functional_tests/test_bundle_custom_fetch.py
+++ b/functional_tests/test_bundle_custom_fetch.py
@@ -5,9 +5,11 @@ that have dependencies that must be installed before the fetch runs.
 """
 
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
+from pathlib import Path
 
 from . import test_config
 
@@ -15,12 +17,21 @@ from . import test_config
 class TestBundleCustomFetch(unittest.TestCase):
     """Tests for bundles with custom fetch functions."""
 
+    def setUp(self):
+        self.cache_root = Path(
+            tempfile.mkdtemp(prefix="envy-bundle-custom-fetch-test-")
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.cache_root, ignore_errors=True)
+
     def run_envy(self, args: list[str], cwd: str = None) -> subprocess.CompletedProcess:
-        """Run envy with given arguments."""
+        """Run envy with given arguments, pinning cache_root to a per-test temp dir."""
         exe = test_config.get_envy_executable()
         env = test_config.get_test_env()
+        full_args = [str(exe), f"--cache-root={self.cache_root}"] + args
         return test_config.run(
-            [str(exe)] + args, cwd=cwd, capture_output=True, text=True, env=env
+            full_args, cwd=cwd, capture_output=True, text=True, env=env
         )
 
     def test_bundle_custom_fetch_simple(self):
@@ -42,6 +53,7 @@ SPECS = {
             # Create simple spec
             simple_spec = """
 IDENTITY = "test.simple@v1"
+USER_MANAGED = true
 CHECK = function(project_root) return true end
 INSTALL = function() end
 """
@@ -103,6 +115,7 @@ PACKAGES = {{
             # Create a user-managed tool spec that the bundle depends on
             tool_spec = """
 IDENTITY = "local.fetcher-tool@v1"
+USER_MANAGED = true
 CHECK = function(project_root)
     return true  -- Always installed
 end
@@ -129,6 +142,7 @@ SPECS = {
 
             from_dep_spec = """
 IDENTITY = "test.from-dep-bundle@v1"
+USER_MANAGED = true
 CHECK = function(project_root) return true end
 INSTALL = function() end
 """

--- a/functional_tests/test_bundle_dependency_order.py
+++ b/functional_tests/test_bundle_dependency_order.py
@@ -77,6 +77,7 @@ SPECS = {{
             spec_lua = f"""IDENTITY = "{spec_id}"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -154,6 +155,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   local helper = envy.loadenv_spec("test.helpers@v1", "lib.helper")
   return helper.compute_value() == 42
@@ -226,6 +228,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   local utils = envy.loadenv_spec("test.helpers@v1", "lib.math.utils")
   return utils.add(1, 2) == 3
@@ -282,6 +285,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   -- Fuzzy match: "toolchain" matches "acme.toolchain@v2"
   local config = envy.loadenv_spec("toolchain", "lib.config")

--- a/functional_tests/test_bundle_deps.py
+++ b/functional_tests/test_bundle_deps.py
@@ -67,6 +67,7 @@ SPECS = {{
             spec_lua = f"""IDENTITY = "{spec_id}"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -109,6 +110,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -154,6 +156,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -203,6 +206,7 @@ DEPENDENCIES = {{
   {{ spec = "test.clang@v1", bundle = "tc" }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -252,6 +256,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -325,6 +330,7 @@ DEPENDENCIES = {
   { spec = "test.gcc@v1", bundle = "unknown_alias" },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -356,6 +362,7 @@ DEPENDENCIES = {
   { bundle = "some.bundle@v1" },  -- No source, no spec - invalid
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_bundle_fetch.py
+++ b/functional_tests/test_bundle_fetch.py
@@ -32,6 +32,7 @@ SPECS = {
     spec_a_lua = """IDENTITY = "test.spec_a@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -44,6 +45,7 @@ end
     spec_b_lua = """IDENTITY = "test.spec_b@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -231,6 +233,7 @@ SPECS = {{
             spec_lua = f"""IDENTITY = "{spec_id}"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -305,6 +308,7 @@ SPECS = {
         spec_lua = """IDENTITY = "test.actual@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -494,6 +498,7 @@ SPECS = {{
             spec_lua = f"""IDENTITY = "{spec_id}"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -569,6 +574,7 @@ SPECS = {
         spec_lua = """IDENTITY = "local.marker@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -616,6 +622,7 @@ SPECS = {
         dummy_lua = """IDENTITY = "local.dummy@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -639,6 +646,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   local helper = envy.loadenv_spec("local.helpers@v1", "lib.helper")
   return helper.HELPER_VERSION == "1.0.0"

--- a/functional_tests/test_check_install_runtime.py
+++ b/functional_tests/test_check_install_runtime.py
@@ -85,6 +85,7 @@ class TestCheckInstallRuntime(unittest.TestCase):
         # Check string success is silent (no TUI output)
         spec = """
 IDENTITY = "local.check_string_success@v1"
+USER_MANAGED = true
 CHECK = "echo 'test'"
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -98,6 +99,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Check string success is silent (no TUI output)
         spec = """
 IDENTITY = "local.check_string_success@v1"
+USER_MANAGED = true
 CHECK = "echo 'test'"
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -113,6 +115,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run quiet=true on success
         spec = """
 IDENTITY = "local.check_ctx_run_quiet@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'test output'", {quiet = true})
     assert(res.exit_code ~= nil, "exit_code field should exist")
@@ -128,6 +131,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run quiet=true on failure (throws)
         spec = """
 IDENTITY = "local.check_ctx_run_quiet_fail@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("exit 1", {quiet = true})
     error("Should have thrown on non-zero exit")
@@ -147,6 +151,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run capture=true returns stdout, stderr, exit_code
         spec = """
 IDENTITY = "local.check_ctx_run_capture@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local cmd = envy.PLATFORM == "windows"
         and "Write-Output 'stdout text'; [Console]::Error.WriteLine('stderr text')"
@@ -168,6 +173,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run capture=false returns only exit_code
         spec = """
 IDENTITY = "local.check_ctx_run_no_capture@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'test'", {capture = false})
     assert(res.exit_code ~= nil, "exit_code field should exist")
@@ -185,6 +191,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run default: streams, throws on non-zero, returns exit_code
         spec = """
 IDENTITY = "local.check_ctx_run_default@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'default test'")
     assert(res.exit_code ~= nil, "exit_code field should exist")
@@ -202,6 +209,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run with neither quiet nor capture
         spec_neither = """
 IDENTITY = "local.check_combo_neither@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'combo test'")
     assert(res.exit_code == 0)
@@ -214,6 +222,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run with quiet=true only
         spec_quiet = """
 IDENTITY = "local.check_combo_quiet@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'quiet test'", {quiet = true})
     assert(res.exit_code == 0)
@@ -226,6 +235,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run with capture=true only
         spec_capture = """
 IDENTITY = "local.check_combo_capture@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'capture test'", {capture = true})
     assert(res.exit_code == 0)
@@ -239,6 +249,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # ctx.run with both quiet=true and capture=true
         spec_both = """
 IDENTITY = "local.check_combo_both@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'both test'", {quiet = true, capture = true})
     assert(res.exit_code == 0)
@@ -266,6 +277,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Check cwd = manifest directory
         spec = """
 IDENTITY = "local.check_cwd_manifest@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     if envy.PLATFORM == "windows" then
         envy.run('"cwd_test" | Out-File -FilePath cwd_check_marker.txt')
@@ -320,6 +332,7 @@ end
         # Install cwd = manifest directory for user-managed packages
         spec = """
 IDENTITY = "local.install_cwd_user@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local marker = os.getenv("ENVY_TEST_INSTALL_MARKER")
     if not marker then error("ENVY_TEST_INSTALL_MARKER not set") end
@@ -367,6 +380,7 @@ end
         # Manifest default_shell respected in check string
         spec = """
 IDENTITY = "local.check_default_shell@v1"
+USER_MANAGED = true
 CHECK = "echo 'shell test'"
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -389,6 +403,7 @@ INSTALL = "echo 'install shell test' > output.txt"
         # Direct table field access patterns
         spec = """
 IDENTITY = "local.check_table_fields@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'test output'", {capture = true})
     local code = res.exit_code
@@ -409,6 +424,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Chained table field access patterns
         spec = """
 IDENTITY = "local.check_table_chained@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local out = envy.run("echo 'chained'", {capture = true}).stdout
     assert(out:match("chained"), "chained stdout access should work")
@@ -427,6 +443,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Shell error: command not found
         spec = """
 IDENTITY = "local.check_error_not_found@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("nonexistent_command_12345", {quiet = true, check = true})
     error("Should have thrown on command not found")
@@ -450,6 +467,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Shell error: syntax error
         spec = """
 IDENTITY = "local.check_error_syntax@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("echo 'unclosed quote", {quiet = true})
     error("Should have thrown on syntax error")
@@ -468,6 +486,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Concurrent large stdout+stderr with capture (no deadlock)
         spec = """
 IDENTITY = "local.check_concurrent@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local cmd
     if envy.PLATFORM == "windows" then
@@ -492,6 +511,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # Empty outputs in failure messages
         spec = """
 IDENTITY = "local.check_empty_output@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local res = envy.run("exit 42", {quiet = true})
     error("Should have thrown on non-zero exit")
@@ -513,6 +533,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         # User-managed tmp_dir lifecycle
         spec = """
 IDENTITY = "local.user_tmp_lifecycle@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local marker = os.getenv("ENVY_TEST_TMP_MARKER")
     if not marker then error("ENVY_TEST_TMP_MARKER not set") end
@@ -559,6 +580,7 @@ end
         # User-managed entry_dir cleanup
         spec = """
 IDENTITY = "local.user_cleanup@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local marker = os.getenv("ENVY_TEST_CLEANUP_MARKER")
     if not marker then error("ENVY_TEST_CLEANUP_MARKER not set") end
@@ -594,6 +616,7 @@ end
         # Check phase does not expose tmp_dir
         spec = """
 IDENTITY = "local.user_check_no_tmp@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     return true
 end
@@ -608,6 +631,7 @@ end
         # User-managed: tmp_dir for workspace, cwd is manifest directory
         spec = """
 IDENTITY = "local.user_tmp_vs_cwd@v1"
+USER_MANAGED = true
 function CHECK(project_root, options)
     local marker = os.getenv("ENVY_TEST_TMP_CWD_MARKER")
     if not marker then error("ENVY_TEST_TMP_CWD_MARKER not set") end

--- a/functional_tests/test_ctx_package_product.py
+++ b/functional_tests/test_ctx_package_product.py
@@ -192,6 +192,7 @@ PACKAGES = {{
         # User-managed provider: CHECK returns true, no persistent cache path
         spec_user_provider = """IDENTITY = "local.ctx_package_user_provider@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return true
 end

--- a/functional_tests/test_engine_dependency_resolution.py
+++ b/functional_tests/test_engine_dependency_resolution.py
@@ -85,6 +85,7 @@ class TestEngineDependencyResolution(unittest.TestCase):
 IDENTITY = "local.simple@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -104,6 +105,7 @@ DEPENDENCIES = {{
   {{ spec = "local.simple@v1", source = "simple.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -148,6 +150,7 @@ DEPENDENCIES = {{
   {{ spec = "local.cycle_b@v1", source = "cycle_b.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -167,6 +170,7 @@ DEPENDENCIES = {{
   {{ spec = "local.cycle_a@v1", source = "cycle_a.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -208,6 +212,7 @@ DEPENDENCIES = {{
   {{ spec = "local.self_dep@v1", source = "self_dep.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -252,6 +257,7 @@ DEPENDENCIES = {{
   {{ spec = "local.diamond_c@v1", source = "diamond_c.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -271,6 +277,7 @@ DEPENDENCIES = {{
   {{ spec = "local.diamond_d@v1", source = "diamond_d.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -290,6 +297,7 @@ DEPENDENCIES = {{
   {{ spec = "local.diamond_d@v1", source = "diamond_d.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -307,6 +315,7 @@ end
 IDENTITY = "local.diamond_d@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -437,6 +446,7 @@ DEPENDENCIES = {{
   {{ spec = "local.independent_right@v1", source = "independent_right.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -454,6 +464,7 @@ end
 IDENTITY = "local.independent_left@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -471,6 +482,7 @@ end
 IDENTITY = "local.independent_right@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -517,6 +529,7 @@ DEPENDENCIES = {{
   {{ spec = "local.with_options@v1", source = "with_options.lua", options = {{ variant = "bar" }} }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -534,6 +547,7 @@ end
 IDENTITY = "local.with_options@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -583,6 +597,7 @@ DEPENDENCIES = {{
   {{ spec = "local.chain_b@v1", source = "chain_b.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -602,6 +617,7 @@ DEPENDENCIES = {{
   {{ spec = "local.chain_c@v1", source = "chain_c.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -621,6 +637,7 @@ DEPENDENCIES = {{
   {{ spec = "local.chain_d@v1", source = "chain_d.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -640,6 +657,7 @@ DEPENDENCIES = {{
   {{ spec = "local.chain_e@v1", source = "chain_e.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -657,6 +675,7 @@ end
 IDENTITY = "local.chain_e@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -709,6 +728,7 @@ DEPENDENCIES = {{
   {{ spec = "local.fanout_child4@v1", source = "fanout_child4.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -726,6 +746,7 @@ end
 IDENTITY = "local.fanout_child1@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -743,6 +764,7 @@ end
 IDENTITY = "local.fanout_child2@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -760,6 +782,7 @@ end
 IDENTITY = "local.fanout_child3@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -777,6 +800,7 @@ end
 IDENTITY = "local.fanout_child4@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -822,6 +846,7 @@ end
 IDENTITY = "local.simple@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -846,6 +871,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -888,6 +914,7 @@ end
 
 IDENTITY = "remote.fileuri@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -930,6 +957,7 @@ end
 
 IDENTITY = "remote.child@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -955,6 +983,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -997,6 +1026,7 @@ end
 
 IDENTITY = "remote.base@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1022,6 +1052,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1064,6 +1095,7 @@ end
 
 IDENTITY = "local.child@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1088,6 +1120,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1130,6 +1163,7 @@ end
 
 IDENTITY = "local.c@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1154,6 +1188,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1179,6 +1214,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1341,6 +1377,7 @@ DEPENDENCIES = {{
 IDENTITY = "local.simple_fetch_dep_child@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1361,6 +1398,7 @@ end
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1445,6 +1483,7 @@ DEPENDENCIES = {{
         local recipe_content_c = [[
 IDENTITY = "local.multi_level_c@v1"
 DEPENDENCIES = {{}}
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1461,6 +1500,7 @@ end
     }}
   }}
 }}
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1478,6 +1518,7 @@ end
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1570,6 +1611,7 @@ DEPENDENCIES = {{
         local recipe_content = [[
 IDENTITY = "local.multiple_fetch_deps_child@v1"
 DEPENDENCIES = {{}}
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -1587,6 +1629,7 @@ end
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_engine_phases.py
+++ b/functional_tests/test_engine_phases.py
@@ -50,6 +50,7 @@ class TestEnginePhases(unittest.TestCase):
         spec = """IDENTITY = "local.simple@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -132,6 +133,7 @@ end
         tool_spec = """IDENTITY = "local.tool@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_engine_spec_loading.py
+++ b/functional_tests/test_engine_spec_loading.py
@@ -52,6 +52,7 @@ class TestEngineSpecLoading(unittest.TestCase):
 IDENTITY = "local.simple@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -127,6 +128,7 @@ DEPENDENCIES = {}
 
 IDENTITY = "remote.child@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -154,6 +156,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -192,6 +195,7 @@ end
 
 IDENTITY = "remote.child@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -218,6 +222,7 @@ DEPENDENCIES = {{
   }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -265,6 +270,7 @@ end
 IDENTITY = "local.identity_correct@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -299,6 +305,7 @@ end
         identity_missing_spec = """-- Spec missing identity declaration (invalid)
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -343,6 +350,7 @@ end
 IDENTITY = "local.wrong_identity@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -392,6 +400,7 @@ end
 IDENTITY = { name = "wrong" }
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -436,6 +445,7 @@ end
             tmp.write("""
 -- Missing identity in local spec
 DEPENDENCIES = {}
+USER_MANAGED = true
 function CHECK(project_root, options) return false end
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """)
@@ -474,6 +484,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = { required = true } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -501,6 +512,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = { required = true } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -527,6 +539,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = {} }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -555,6 +568,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = { type = "semver" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -582,6 +596,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = { type = "semver" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -610,6 +625,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = { type = "semver", range = ">=1.0.0 <2.0.0" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -637,6 +653,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = { type = "semver", range = ">=1.0.0 <2.0.0" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -665,6 +682,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { count = { range = ">=1 <10" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -692,6 +710,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { count = { range = ">=1 <10" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -720,6 +739,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { mode = { validate = function(v) end } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -747,6 +767,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { mode = { validate = function(v) return "bad mode: " .. v end } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -775,6 +796,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { version = {} }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -800,6 +822,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = {}
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -827,6 +850,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { name = { type = "string" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -854,6 +878,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { name = { type = "string" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -882,6 +907,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { items = { type = "list" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -909,6 +935,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { items = { type = "list" } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -937,6 +964,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { mode = { choices = { "install", "extract" } } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -964,6 +992,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = { mode = { choices = { "install", "extract" } } }
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -994,6 +1023,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = function(opts) end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1019,6 +1049,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = function(opts) return true end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1044,6 +1075,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = function(opts) return false end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1070,6 +1102,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = function(opts) return "nope" end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1096,6 +1129,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = function(opts) return 123 end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1122,6 +1156,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = function(opts) error("boom") end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1150,6 +1185,7 @@ OPTIONS = function(opts)
   envy.options({ version = { required = true } })
 end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1179,6 +1215,7 @@ OPTIONS = function(opts)
   envy.options({ version = { required = true } })
 end
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1207,6 +1244,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = 42
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """
@@ -1233,6 +1271,7 @@ INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 
 OPTIONS = "string"
 
+USER_MANAGED = true
 CHECK = function(project_root, options) return true end
 INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
 """

--- a/functional_tests/test_engine_weak_dependencies.py
+++ b/functional_tests/test_engine_weak_dependencies.py
@@ -55,6 +55,7 @@ DEPENDENCIES = {
   { spec = "local.missing_dep", weak = { spec = "local.weak_fallback@v1", source = "weak_fallback.lua" } },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -70,6 +71,7 @@ end
 IDENTITY = "local.weak_fallback@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -99,6 +101,7 @@ DEPENDENCIES = {
   { spec = "local.existing_dep", weak = { spec = "local.unused_fallback@v1", source = "weak_unused_fallback.lua" } },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -114,6 +117,7 @@ end
 IDENTITY = "local.existing_dep@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -129,6 +133,7 @@ end
 IDENTITY = "local.unused_fallback@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -158,6 +163,7 @@ DEPENDENCIES = {
   { spec = "local.weak_provider" },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -173,6 +179,7 @@ end
 IDENTITY = "local.weak_provider@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -202,6 +209,7 @@ DEPENDENCIES = {
   { spec = "local.dupe" },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -217,6 +225,7 @@ end
 IDENTITY = "local.dupe@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -232,6 +241,7 @@ end
 IDENTITY = "local.dupe@v2"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -259,6 +269,7 @@ DEPENDENCIES = {
   { spec = "local.never_provided" },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -285,6 +296,7 @@ DEPENDENCIES = {
   { spec = "local.chain_missing", weak = { spec = "local.chain_b@v1", source = "weak_chain_b.lua" } },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -302,6 +314,7 @@ DEPENDENCIES = {
   { spec = "local.chain_c", weak = { spec = "local.chain_c@v1", source = "weak_chain_c.lua" } },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -317,6 +330,7 @@ end
 IDENTITY = "local.chain_c@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -347,6 +361,7 @@ DEPENDENCIES = {
   { spec = "local.shared" },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -364,6 +379,7 @@ DEPENDENCIES = {
   { spec = "local.shared", weak = { spec = "local.shared@v1", source = "weak_shared.lua" } },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -381,6 +397,7 @@ DEPENDENCIES = {
   { spec = "local.shared", weak = { spec = "local.shared@v1", source = "weak_shared.lua" } },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -396,6 +413,7 @@ end
 IDENTITY = "local.shared@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -442,6 +460,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
   -- No-op; custom fetch dependency performs work, root install not needed.
 end
 
+USER_MANAGED = true
 function CHECK(project_root, options) return true end
 ]])
         f:close()
@@ -455,6 +474,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
   -- No-op; check returns true so install is skipped.
 end
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return true
 end
@@ -465,6 +485,7 @@ end
         weak_helper_fallback = """-- Fallback helper for weak custom fetch dependency
 IDENTITY = "local.helper.fallback@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return true
 end
@@ -515,6 +536,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
   -- No-op; custom fetch dependency performs work, root install not needed.
 end
 
+USER_MANAGED = true
 function CHECK(project_root, options) return true end
 ]])
         f:close()
@@ -528,6 +550,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
   -- No-op; check returns true so install is skipped.
 end
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return true
 end
@@ -540,6 +563,7 @@ end
         weak_helper_strong = """-- Strong provider for helper identity
 IDENTITY = "local.helper@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return true
 end
@@ -554,6 +578,7 @@ end
         weak_helper_fallback = """-- Fallback helper for weak custom fetch dependency
 IDENTITY = "local.helper.fallback@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return true
 end
@@ -586,6 +611,7 @@ DEPENDENCIES = {
   { spec = "local.foo@v1", source = "weak_cycle_b.lua" },
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -603,6 +629,7 @@ DEPENDENCIES = {
   { spec = "foo" },  -- Weak ref-only, will match weak_cycle_b
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -620,6 +647,7 @@ DEPENDENCIES = {
   { spec = "local.weak_cycle_a@v1", source = "weak_cycle_a.lua" }
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_fetch_git.py
+++ b/functional_tests/test_fetch_git.py
@@ -276,10 +276,6 @@ IDENTITY = "test.ninja@v1"
 
 FETCH = { source = "https://github.com/ninja-build/ninja.git", ref = "v1.13.2" }
 
-function CHECK(project_root, options)
-    return false
-end
-
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
     -- Nothing needed - source is already fetched by git
 end

--- a/functional_tests/test_loadenv.py
+++ b/functional_tests/test_loadenv.py
@@ -88,6 +88,7 @@ DEPENDENCIES = {}
 local helper = envy.loadenv("helper")
 LOADED_VALUE = helper.HELPER_VALUE
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -121,6 +122,7 @@ PACKAGES = {{
         spec_content = """IDENTITY = "local.phase-loadenv@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   local ver = envy.loadenv("version")
   return ver.TOOL_VERSION == "1.2.3"
@@ -169,6 +171,7 @@ assert(FOO == nil, "FOO leaked to _G")
 assert(BAR == nil, "BAR leaked to _G")
 assert(BAZ == nil, "BAZ leaked to _G")
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -208,6 +211,7 @@ DEPENDENCIES = {}
 local helper = envy.loadenv("subdir.helper")
 assert(helper.SUBDIR_VALUE == "in_subdir", "Failed to load from subdir")
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -277,6 +281,7 @@ assert(helper.RESULTS.str == "value: 42", "string.format failed")
 assert(helper.RESULTS.math_val == 3, "math.floor failed")
 assert(helper.RESULTS.tbl == "a,b,c", "table.concat failed")
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -340,6 +345,7 @@ DEPENDENCIES = {}
 
 local helper = envy.loadenv("nonexistent")
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_loadenv_spec.py
+++ b/functional_tests/test_loadenv_spec.py
@@ -75,6 +75,7 @@ SPECS = {{
             spec_lua = f"""IDENTITY = "{spec_id}"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -131,6 +132,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   local helper = envy.loadenv_spec("test.helpers@v1", "lib.helper")
   return helper.HELPER_VERSION == "1.0.0"
@@ -176,6 +178,7 @@ DEPENDENCIES = {{
 -- This should ERROR - loadenv_spec at global scope
 local helper = envy.loadenv_spec("test.helpers@v1", "lib.helper")
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -209,6 +212,7 @@ PACKAGES = {{
         spec_content = """IDENTITY = "local.undeclared@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   -- Error: test.helpers@v1 not declared as dependency
   local helper = envy.loadenv_spec("test.helpers@v1", "lib.helper")
@@ -263,6 +267,7 @@ DEPENDENCIES = {{
   }},
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   -- Fuzzy match: "toolchain-helpers" matches "acme.toolchain-helpers@v2"
   local helper = envy.loadenv_spec("toolchain-helpers", "lib.helper")
@@ -366,6 +371,7 @@ DEPENDENCIES = {}
 -- This require should work because bundle root is in package.path
 local helper = require("lib.helper")
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return helper.VERSION == "2.0.0"
 end

--- a/functional_tests/test_needed_by.py
+++ b/functional_tests/test_needed_by.py
@@ -65,6 +65,7 @@ end
 SIMPLE_SPEC = """-- Minimal test spec
 IDENTITY = "local.simple@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
     return false
 end

--- a/functional_tests/test_package.py
+++ b/functional_tests/test_package.py
@@ -150,6 +150,7 @@ DEPENDENCIES = {
   { spec = "local.diamond_c@v1", source = "diamond_c.lua" }
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -164,6 +165,7 @@ DEPENDENCIES = {
   { spec = "local.diamond_d@v1", source = "diamond_d.lua" }
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -178,6 +180,7 @@ DEPENDENCIES = {
   { spec = "local.diamond_d@v1", source = "diamond_d.lua" }
 }
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -190,6 +193,7 @@ end
 IDENTITY = "local.diamond_d@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -201,6 +205,7 @@ end
             "install_programmatic.lua": """-- Test programmatic package (user-managed)
 IDENTITY = "local.programmatic@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_package_depot.py
+++ b/functional_tests/test_package_depot.py
@@ -1468,6 +1468,7 @@ class TestUserManagedSkipsDepot(unittest.TestCase):
         mp = marker_path.as_posix()
         content = f'''IDENTITY = "{identity}"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
     local f = io.open("{mp}", "r")
     if f then f:close(); return true end

--- a/functional_tests/test_platform_filter.py
+++ b/functional_tests/test_platform_filter.py
@@ -87,6 +87,7 @@ end
 SPEC_USER_MANAGED = """\
 IDENTITY = "local.usermanaged@v1"
 
+USER_MANAGED = true
 CHECK = function(project_root, options)
   return false
 end

--- a/functional_tests/test_products.py
+++ b/functional_tests/test_products.py
@@ -51,6 +51,7 @@ SPEC_PRODUCT_PROGRAMMATIC = """-- Programmatic provider (user-managed) returning
 IDENTITY = "local.product_programmatic@v1"
 PRODUCTS = {{ tool = "programmatic-tool" }}
 
+USER_MANAGED = true
 CHECK = function(project_root, options)
   return true  -- Already satisfied; no cache artifact
 end

--- a/functional_tests/test_structured_trace.py
+++ b/functional_tests/test_structured_trace.py
@@ -19,6 +19,7 @@ from .trace_parser import TraceParser
 SIMPLE_SPEC = """IDENTITY = "local.simple@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_sync.py
+++ b/functional_tests/test_sync.py
@@ -57,6 +57,7 @@ def create_test_archive(output_path: Path) -> str:
 SPEC_SIMPLE = """IDENTITY = "local.simple@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -86,6 +87,7 @@ end
 SPEC_DIAMOND_D = """IDENTITY = "local.diamond_d@v1"
 DEPENDENCIES = {{}}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -100,6 +102,7 @@ DEPENDENCIES = {{
   {{ spec = "local.diamond_d@v1", source = "diamond_d.lua" }}
 }}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_tui.py
+++ b/functional_tests/test_tui.py
@@ -17,6 +17,7 @@ from .test_config import make_manifest
 # User-managed spec that runs shell commands during install
 SPEC_BUILD_FUNCTION = """IDENTITY = "local.build_function@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -30,6 +31,7 @@ end
 # Dependency spec for parallel execution test
 SPEC_BUILD_DEPENDENCY = """IDENTITY = "local.build_dependency@v1"
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end
@@ -42,6 +44,7 @@ end
 
 # Fast-completing spec (instant install)
 SPEC_FAST = """IDENTITY = "local.fast@v1"
+USER_MANAGED = true
 function CHECK(project_root, options) return false end
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
   envy.run("echo fast-install-done", { quiet = true })
@@ -50,6 +53,7 @@ end
 
 # Slow spec (sleeps to keep renderer active)
 SPEC_SLOW = """IDENTITY = "local.slow@v1"
+USER_MANAGED = true
 function CHECK(project_root, options) return false end
 function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
   envy.run("sleep 2")
@@ -60,6 +64,7 @@ end
 SPEC_SIMPLE = """IDENTITY = "local.simple@v1"
 DEPENDENCIES = {}
 
+USER_MANAGED = true
 function CHECK(project_root, options)
   return false
 end

--- a/functional_tests/test_user_managed.py
+++ b/functional_tests/test_user_managed.py
@@ -451,6 +451,7 @@ function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
         result = self.run_spec("fn_form_bad", "local.um_fn_form_bad@v1")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must return a boolean", result.stderr)
+        self.assertIn("local.um_fn_form_bad@v1", result.stderr)
 
 
 if __name__ == "__main__":

--- a/functional_tests/test_user_managed.py
+++ b/functional_tests/test_user_managed.py
@@ -16,6 +16,7 @@ from . import test_config
 # Simple user-managed package: check if marker file exists, create if not
 # Simulates system package wrapper (like brew install python)
 SPEC_SIMPLE = """IDENTITY = "local.user_managed_simple@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options)
     local marker = os.getenv("ENVY_TEST_MARKER_SIMPLE")
@@ -38,6 +39,7 @@ end
 # Context isolation test: verify restricted directory access for user-managed
 # Tests install_dir=nil, stage_dir access, fetch_dir access, extract_all behavior
 SPEC_CTX_FORBIDDEN = """IDENTITY = "local.user_managed_ctx_isolation_forbidden@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options)
     return false
@@ -278,6 +280,7 @@ end
         """User-managed packages cannot access install_dir (it's nil)."""
         # User-managed spec that tries to use install_dir
         spec_invalid = """IDENTITY = "local.user_managed_invalid@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options)
     return false
@@ -304,6 +307,7 @@ end
         """User-managed packages can access and use tmp_dir."""
         # Spec that verifies tmp_dir is accessible and writable
         spec_tmp_dir = """IDENTITY = "local.user_managed_ctx_isolation_tmp_dir@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options)
     return false
@@ -337,6 +341,7 @@ end
         """User-managed packages can access allowed APIs (run, package, product)."""
         # Spec that verifies envy.* APIs are accessible
         spec_allowed = """IDENTITY = "local.user_managed_ctx_isolation_allowed@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options)
     return false
@@ -397,6 +402,55 @@ end
             env_vars={"ENVY_TEST_FORBIDDEN_API": "extract_all"},
         )
         self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+
+    # =========================================================================
+    # USER_MANAGED resolution forms (boolean / function / errors)
+    # =========================================================================
+
+    def test_user_managed_function_form_returning_true(self):
+        """USER_MANAGED = function() return true end classifies the spec as user-managed."""
+        spec = """IDENTITY = "local.um_fn_form_true@v1"
+USER_MANAGED = function() return envy.PLATFORM ~= "<<never>>" end
+
+function CHECK(project_root, options)
+    local marker = os.getenv("ENVY_TEST_MARKER_FN")
+    local f = io.open(marker, "r")
+    if f then f:close(); return true end
+    return false
+end
+
+function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options)
+    if install_dir ~= nil then
+        error("install_dir should be nil for user-managed packages")
+    end
+    local marker = os.getenv("ENVY_TEST_MARKER_FN")
+    local f = io.open(marker, "w")
+    f:write("installed via function-form USER_MANAGED")
+    f:close()
+end
+"""
+        marker = self.marker_dir / "marker-fn-form"
+        self.write_spec("fn_form_true", spec)
+        result = self.run_spec(
+            "fn_form_true",
+            "local.um_fn_form_true@v1",
+            env_vars={"ENVY_TEST_MARKER_FN": str(marker)},
+        )
+        self.assertEqual(result.returncode, 0, f"stderr: {result.stderr}")
+        self.assertTrue(marker.exists(), "INSTALL should have run and created the marker")
+
+    def test_user_managed_function_form_returning_non_boolean_fails(self):
+        """USER_MANAGED function returning a non-boolean errors with identity in message."""
+        spec = """IDENTITY = "local.um_fn_form_bad@v1"
+USER_MANAGED = function() return "yes" end
+
+function CHECK(project_root, options) return false end
+function INSTALL(install_dir, stage_dir, fetch_dir, tmp_dir, options) end
+"""
+        self.write_spec("fn_form_bad", spec)
+        result = self.run_spec("fn_form_bad", "local.um_fn_form_bad@v1")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must return a boolean", result.stderr)
 
 
 if __name__ == "__main__":

--- a/src/phases/phase_check.cpp
+++ b/src/phases/phase_check.cpp
@@ -114,12 +114,6 @@ bool run_check_verb(pkg *p, engine &eng, sol::state_view lua) {
   return false;
 }
 
-// Helper: Check if package has check verb
-bool pkg_has_check_verb(pkg *p, sol::state_view lua) {
-  sol::object check_obj{ lua["CHECK"] };
-  return check_obj.is<sol::protected_function>() || check_obj.is<std::string>();
-}
-
 // Helper: Compute hash and perform cache lookup (common to both user/cache-managed)
 cache::ensure_result compute_hash_and_lookup_cache(pkg *p, sol::state_view lua) {
   // Compute hash including resolved weak/ref-only dependencies
@@ -219,10 +213,7 @@ void run_check_phase(pkg *p, engine &eng) {
 
   sol::state_view lua{ *p->lua };
 
-  // Check if package has check verb (user-managed package indicator)
-  bool const has_check{ pkg_has_check_verb(p, lua) };
-
-  if (has_check) {
+  if (p->type == pkg_type::USER_MANAGED) {
     run_check_phase_user_managed(p, eng, lua);
   } else {
     run_check_phase_cache_managed(p, eng);

--- a/src/phases/phase_check.h
+++ b/src/phases/phase_check.h
@@ -8,6 +8,5 @@ class engine;
 struct pkg;
 
 void run_check_phase(pkg *p, engine &eng);
-bool pkg_has_check_verb(pkg *p, sol::state_view lua);
 
 }  // namespace envy

--- a/src/phases/phase_check_tests.cpp
+++ b/src/phases/phase_check_tests.cpp
@@ -15,7 +15,6 @@
 namespace envy {
 
 // Extern declarations for unit testing (not in public API)
-extern bool pkg_has_check_verb(pkg *p, sol::state_view lua);
 extern bool run_check_verb(pkg *p, engine &eng, sol::state_view lua);
 extern bool run_check_string(pkg *p, engine &eng, std::string_view check_cmd);
 extern bool run_check_function(pkg *p,
@@ -84,50 +83,6 @@ struct test_pkg_fixture {
 };
 
 }  // namespace
-
-// ============================================================================
-// pkg_has_check_verb() tests
-// ============================================================================
-
-TEST_CASE("pkg_has_check_verb detects string check") {
-  test_pkg_fixture f;
-  f.set_check_string("true");
-
-  bool has_check = pkg_has_check_verb(f.p.get(), sol::state_view{ *f.p->lua });
-  CHECK(has_check);
-}
-
-TEST_CASE("pkg_has_check_verb detects function check") {
-  test_pkg_fixture f;
-  f.set_check_function("function(project_root) return true end");
-
-  bool has_check = pkg_has_check_verb(f.p.get(), sol::state_view{ *f.p->lua });
-  CHECK(has_check);
-}
-
-TEST_CASE("pkg_has_check_verb returns false when no check verb") {
-  test_pkg_fixture f;
-  // No check verb set
-
-  bool has_check = pkg_has_check_verb(f.p.get(), sol::state_view{ *f.p->lua });
-  CHECK_FALSE(has_check);
-}
-
-TEST_CASE("pkg_has_check_verb returns false for number") {
-  test_pkg_fixture f;
-  (*f.p->lua)["CHECK"] = 42;
-
-  bool has_check{ pkg_has_check_verb(f.p.get(), sol::state_view{ *f.p->lua }) };
-  CHECK_FALSE(has_check);
-}
-
-TEST_CASE("pkg_has_check_verb returns false for invalid check type (table)") {
-  test_pkg_fixture f;
-  (*f.p->lua)["CHECK"] = f.p->lua->create_table();
-
-  bool has_check = pkg_has_check_verb(f.p.get(), sol::state_view{ *f.p->lua });
-  CHECK_FALSE(has_check);
-}
 
 // ============================================================================
 // run_check_string() tests

--- a/src/phases/phase_install.cpp
+++ b/src/phases/phase_install.cpp
@@ -5,7 +5,6 @@
 #include "lua_ctx/lua_phase_context.h"
 #include "lua_envy.h"
 #include "lua_error_formatter.h"
-#include "phase_check.h"
 #include "pkg.h"
 #include "pkg_cfg.h"
 #include "platform.h"
@@ -207,7 +206,7 @@ void run_install_phase(pkg *p, engine &eng) {
   sol::object install_obj{ lua_view["INSTALL"] };
   bool marked_complete{ false };
 
-  bool const is_user_managed{ pkg_has_check_verb(p, lua_view) };
+  bool const is_user_managed{ p->type == pkg_type::USER_MANAGED };
 
   if (!install_obj.valid()) {
     marked_complete = promote_stage_to_install(lock.get());

--- a/src/phases/phase_install_tests.cpp
+++ b/src/phases/phase_install_tests.cpp
@@ -86,10 +86,16 @@ struct install_test_fixture {
 
   sol::state_view lua_state() { return sol::state_view{ *p->lua }; }
 
-  void clear_check_verb() { lua_state()["CHECK"] = sol::lua_nil; }
+  // Mark fixture as user-managed (was: implicit via CHECK presence).
+  // Also sets CHECK in the Lua state for tests that exercise CHECK dispatch.
+  void clear_check_verb() {
+    lua_state()["CHECK"] = sol::lua_nil;
+    p->type = pkg_type::CACHE_MANAGED;
+  }
 
   void set_check_verb(std::string_view check_code) {
     lua_state()["CHECK"] = std::string(check_code);
+    p->type = pkg_type::USER_MANAGED;
   }
 
   void clear_install_verb() { lua_state()["INSTALL"] = sol::lua_nil; }

--- a/src/phases/phase_install_tests.cpp
+++ b/src/phases/phase_install_tests.cpp
@@ -86,13 +86,15 @@ struct install_test_fixture {
 
   sol::state_view lua_state() { return sol::state_view{ *p->lua }; }
 
-  // Mark fixture as user-managed (was: implicit via CHECK presence).
-  // Also sets CHECK in the Lua state for tests that exercise CHECK dispatch.
+  // Configure the fixture as cache-managed (CHECK cleared, type = CACHE_MANAGED).
   void clear_check_verb() {
     lua_state()["CHECK"] = sol::lua_nil;
     p->type = pkg_type::CACHE_MANAGED;
   }
 
+  // Configure the fixture as user-managed (CHECK set, type = USER_MANAGED).
+  // Dispatch in run_install_phase keys on p->type, but tests that exercise
+  // run_check_verb() still need CHECK populated in the Lua state.
   void set_check_verb(std::string_view check_code) {
     lua_state()["CHECK"] = std::string(check_code);
     p->type = pkg_type::USER_MANAGED;

--- a/src/phases/phase_spec_fetch.cpp
+++ b/src/phases/phase_spec_fetch.cpp
@@ -57,8 +57,10 @@ bool resolve_user_managed(sol::state_view lua, std::string const &identity) {
 void validate_phases(sol::state_view lua, std::string const &identity, bool user_managed) {
   bool const has_fetch{ lua["FETCH"].is<sol::protected_function>() ||
                         lua["FETCH"].is<std::string>() || lua["FETCH"].is<sol::table>() };
-  bool const has_stage{ lua["STAGE"].is<sol::protected_function>() };
-  bool const has_build{ lua["BUILD"].is<sol::protected_function>() };
+  bool const has_stage{ lua["STAGE"].is<sol::protected_function>() ||
+                        lua["STAGE"].is<std::string>() || lua["STAGE"].is<sol::table>() };
+  bool const has_build{ lua["BUILD"].is<sol::protected_function>() ||
+                        lua["BUILD"].is<std::string>() };
   bool const has_check{ lua["CHECK"].is<sol::protected_function>() ||
                         lua["CHECK"].is<std::string>() };
   bool const has_install{ lua["INSTALL"].is<sol::protected_function>() ||

--- a/src/phases/phase_spec_fetch.cpp
+++ b/src/phases/phase_spec_fetch.cpp
@@ -25,22 +25,83 @@ namespace envy {
 
 namespace {
 
-void validate_phases(sol::state_view lua, std::string const &identity) {
-  sol::object fetch_obj{ lua["FETCH"] };
+bool resolve_user_managed(sol::state_view lua, std::string const &identity) {
+  sol::object obj{ lua["USER_MANAGED"] };
+  if (!obj.valid() || obj.get_type() == sol::type::lua_nil) { return false; }
 
-  if (bool const has_fetch{ fetch_obj.is<sol::protected_function>() ||
-                            fetch_obj.is<std::string>() || fetch_obj.is<sol::table>() }) {
-    return;
+  if (obj.get_type() == sol::type::boolean) { return obj.as<bool>(); }
+
+  if (obj.is<sol::protected_function>()) {
+    if (sol::protected_function_result result{ obj.as<sol::protected_function>()() };
+        !result.valid()) {
+      sol::error err = result;
+      throw std::runtime_error("USER_MANAGED function failed for " + identity + ": " +
+                               std::string{ err.what() });
+    } else {
+      sol::object ret{ result };
+      if (ret.get_type() != sol::type::boolean) {
+        throw std::runtime_error(
+            std::string{ "USER_MANAGED function must return a boolean (got " } +
+            sol::type_name(lua.lua_state(), ret.get_type()) + ") for " + identity);
+      }
+      return ret.as<bool>();
+    }
   }
 
+  throw std::runtime_error(
+      std::string{ "USER_MANAGED must be a boolean or function returning a boolean "
+                   "(got " } +
+      sol::type_name(lua.lua_state(), obj.get_type()) + ") for " + identity);
+}
+
+void validate_phases(sol::state_view lua, std::string const &identity, bool user_managed) {
+  bool const has_fetch{ lua["FETCH"].is<sol::protected_function>() ||
+                        lua["FETCH"].is<std::string>() ||
+                        lua["FETCH"].is<sol::table>() };
+  bool const has_stage{ lua["STAGE"].is<sol::protected_function>() };
+  bool const has_build{ lua["BUILD"].is<sol::protected_function>() };
   bool const has_check{ lua["CHECK"].is<sol::protected_function>() ||
                         lua["CHECK"].is<std::string>() };
   bool const has_install{ lua["INSTALL"].is<sol::protected_function>() ||
                           lua["INSTALL"].is<std::string>() };
 
-  if (!has_check || !has_install) {
-    throw std::runtime_error("Spec must define 'FETCH' or both 'CHECK' and 'INSTALL': " +
-                             identity);
+  if (user_managed) {
+    if (!has_check) {
+      throw std::runtime_error("User-managed spec must define 'CHECK': " + identity);
+    }
+    if (!has_install) {
+      throw std::runtime_error("User-managed spec must define 'INSTALL': " + identity);
+    }
+    if (has_fetch) {
+      throw std::runtime_error(
+          "Spec " + identity +
+          " is user-managed (USER_MANAGED=true) but declares FETCH phase. "
+          "User-managed packages cannot use cache-managed phases (FETCH/STAGE/BUILD). "
+          "Remove FETCH phase or set USER_MANAGED=false.");
+    }
+    if (has_stage) {
+      throw std::runtime_error(
+          "Spec " + identity +
+          " is user-managed (USER_MANAGED=true) but declares STAGE phase. "
+          "User-managed packages cannot use cache-managed phases (FETCH/STAGE/BUILD). "
+          "Remove STAGE phase or set USER_MANAGED=false.");
+    }
+    if (has_build) {
+      throw std::runtime_error(
+          "Spec " + identity +
+          " is user-managed (USER_MANAGED=true) but declares BUILD phase. "
+          "User-managed packages cannot use cache-managed phases (FETCH/STAGE/BUILD). "
+          "Remove BUILD phase or set USER_MANAGED=false.");
+    }
+  } else {
+    if (has_check) {
+      throw std::runtime_error("Spec " + identity +
+                               " defines CHECK but USER_MANAGED is not true; "
+                               "CHECK is only valid for user-managed packages");
+    }
+    if (!has_fetch) {
+      throw std::runtime_error("Spec must define 'FETCH': " + identity);
+    }
   }
 }
 
@@ -66,42 +127,6 @@ int load_spec_script(sol::state &lua,
   if (!result.valid()) {
     sol::error err = result;
     throw std::runtime_error("Failed to load spec: " + identity + ": " + err.what());
-  }
-
-  // Validate user-managed packages (check verb) don't use cache phases
-  sol::object check_obj{ lua["CHECK"] };
-  bool const has_check_verb{ check_obj.valid() &&
-                             (check_obj.is<std::string>() ||
-                              check_obj.is<sol::protected_function>()) };
-
-  if (has_check_verb) {
-    // User-managed packages cannot use fetch/stage/build phases
-    sol::object fetch_obj{ lua["FETCH"] };
-    if (fetch_obj.valid() && fetch_obj.is<sol::protected_function>()) {
-      throw std::runtime_error(
-          "Spec " + identity +
-          " has CHECK verb (user-managed) but declares FETCH phase. "
-          "User-managed packages cannot use cache-managed phases (FETCH/STAGE/BUILD). "
-          "Remove CHECK verb or remove FETCH phase.");
-    }
-
-    sol::object stage_obj{ lua["STAGE"] };
-    if (stage_obj.valid() && stage_obj.is<sol::protected_function>()) {
-      throw std::runtime_error(
-          "Spec " + identity +
-          " has CHECK verb (user-managed) but declares STAGE phase. "
-          "User-managed packages cannot use cache-managed phases (FETCH/STAGE/BUILD). "
-          "Remove CHECK verb or remove STAGE phase.");
-    }
-
-    sol::object build_obj{ lua["BUILD"] };
-    if (build_obj.valid() && build_obj.is<sol::protected_function>()) {
-      throw std::runtime_error(
-          "Spec " + identity +
-          " has CHECK verb (user-managed) but declares BUILD phase. "
-          "User-managed packages cannot use cache-managed phases (FETCH/STAGE/BUILD). "
-          "Remove CHECK verb or remove BUILD phase.");
-    }
   }
 
   return meta.schema;
@@ -1240,25 +1265,12 @@ void run_spec_fetch_phase(pkg *p, engine &eng) {
                              "' but spec declares '" + declared_identity + "'");
   }
 
-  validate_phases(sol::state_view{ *lua }, cfg.identity);
-
-  // Determine package type (user-managed or cache-managed)
+  // Determine package type (user-managed or cache-managed) and validate phases.
   {
     sol::state_view lua_view{ *lua };
-    bool const has_check{ lua_view["CHECK"].is<sol::protected_function>() ||
-                          lua_view["CHECK"].is<std::string>() };
-    bool const has_install{ lua_view["INSTALL"].is<sol::protected_function>() ||
-                            lua_view["INSTALL"].is<std::string>() };
-
-    if (has_check) {
-      if (!has_install) {
-        throw std::runtime_error("User-managed spec must define 'install' function: " +
-                                 cfg.identity);
-      }
-      p->type = pkg_type::USER_MANAGED;
-    } else {
-      p->type = pkg_type::CACHE_MANAGED;
-    }
+    bool const user_managed{ resolve_user_managed(lua_view, cfg.identity) };
+    validate_phases(lua_view, cfg.identity, user_managed);
+    p->type = user_managed ? pkg_type::USER_MANAGED : pkg_type::CACHE_MANAGED;
   }
 
   p->products = parse_products_table(cfg, *lua, p);

--- a/src/phases/phase_spec_fetch.cpp
+++ b/src/phases/phase_spec_fetch.cpp
@@ -56,8 +56,7 @@ bool resolve_user_managed(sol::state_view lua, std::string const &identity) {
 
 void validate_phases(sol::state_view lua, std::string const &identity, bool user_managed) {
   bool const has_fetch{ lua["FETCH"].is<sol::protected_function>() ||
-                        lua["FETCH"].is<std::string>() ||
-                        lua["FETCH"].is<sol::table>() };
+                        lua["FETCH"].is<std::string>() || lua["FETCH"].is<sol::table>() };
   bool const has_stage{ lua["STAGE"].is<sol::protected_function>() };
   bool const has_build{ lua["BUILD"].is<sol::protected_function>() };
   bool const has_check{ lua["CHECK"].is<sol::protected_function>() ||
@@ -99,9 +98,7 @@ void validate_phases(sol::state_view lua, std::string const &identity, bool user
                                " defines CHECK but USER_MANAGED is not true; "
                                "CHECK is only valid for user-managed packages");
     }
-    if (!has_fetch) {
-      throw std::runtime_error("Spec must define 'FETCH': " + identity);
-    }
+    if (!has_fetch) { throw std::runtime_error("Spec must define 'FETCH': " + identity); }
   }
 }
 

--- a/src/phases/phase_spec_fetch_tests.cpp
+++ b/src/phases/phase_spec_fetch_tests.cpp
@@ -38,26 +38,30 @@ struct temp_dir_guard {
   ~temp_dir_guard() { std::filesystem::remove_all(path); }
 };
 
-void expect_user_managed_cache_phase_error(std::string const &phase_name) {
+void expect_user_managed_cache_phase_error(std::string const &phase_name,
+                                           std::string const &phase_rhs,
+                                           std::string const &label_suffix = "") {
   cache c;
   engine eng{ c };
 
   std::filesystem::path temp_dir{ std::filesystem::temp_directory_path() /
-                                  ("envy_test_check_" + phase_name) };
+                                  ("envy_test_check_" + phase_name + label_suffix) };
   std::filesystem::create_directories(temp_dir);
   temp_dir_guard guard{ temp_dir };
   std::filesystem::path spec_file{ temp_dir / "spec.lua" };
 
+  std::string const identity{ "test.check_" + phase_name + label_suffix + "@v1" };
+
   {
     std::ofstream ofs{ spec_file };
-    ofs << "IDENTITY = \"test.check_" << phase_name << "@v1\"\n";
+    ofs << "IDENTITY = \"" << identity << "\"\n";
     ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = \"echo test\"\n";
     ofs << "INSTALL = \"echo install\"\n";
-    ofs << phase_name << " = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
+    ofs << phase_name << " = " << phase_rhs << "\n";
   }
 
-  auto *cfg{ make_local_cfg("test.check_" + phase_name + "@v1", spec_file) };
+  auto *cfg{ make_local_cfg(identity, spec_file) };
   pkg *p{ eng.ensure_pkg(cfg) };
 
   bool exception_thrown = false;
@@ -116,16 +120,40 @@ TEST_CASE("string check without install errors") {
 // User-managed package validation tests (check verb + cache phases)
 // ============================================================================
 
-TEST_CASE("user-managed package with check verb and fetch phase throws parse error") {
-  expect_user_managed_cache_phase_error("FETCH");
+TEST_CASE("user-managed package with check verb and FETCH function throws parse error") {
+  expect_user_managed_cache_phase_error(
+      "FETCH", "function(install_dir, stage_dir, fetch_dir, tmp_dir) end", "_fn");
 }
 
-TEST_CASE("user-managed package with check verb and stage phase throws parse error") {
-  expect_user_managed_cache_phase_error("STAGE");
+TEST_CASE("user-managed package with check verb and FETCH string throws parse error") {
+  expect_user_managed_cache_phase_error("FETCH", "\"https://example.com/x.tar.gz\"", "_str");
 }
 
-TEST_CASE("user-managed package with check verb and build phase throws parse error") {
-  expect_user_managed_cache_phase_error("BUILD");
+TEST_CASE("user-managed package with check verb and FETCH table throws parse error") {
+  expect_user_managed_cache_phase_error(
+      "FETCH", "{ url = \"https://example.com/x.tar.gz\" }", "_tbl");
+}
+
+TEST_CASE("user-managed package with check verb and STAGE function throws parse error") {
+  expect_user_managed_cache_phase_error(
+      "STAGE", "function(install_dir, stage_dir, fetch_dir, tmp_dir) end", "_fn");
+}
+
+TEST_CASE("user-managed package with check verb and STAGE string throws parse error") {
+  expect_user_managed_cache_phase_error("STAGE", "\"echo stage\"", "_str");
+}
+
+TEST_CASE("user-managed package with check verb and STAGE table throws parse error") {
+  expect_user_managed_cache_phase_error("STAGE", "{ strip_components = 1 }", "_tbl");
+}
+
+TEST_CASE("user-managed package with check verb and BUILD function throws parse error") {
+  expect_user_managed_cache_phase_error(
+      "BUILD", "function(install_dir, stage_dir, fetch_dir, tmp_dir) end", "_fn");
+}
+
+TEST_CASE("user-managed package with check verb and BUILD string throws parse error") {
+  expect_user_managed_cache_phase_error("BUILD", "\"make\"", "_str");
 }
 
 TEST_CASE("user-managed package with check verb and install phase succeeds") {

--- a/src/phases/phase_spec_fetch_tests.cpp
+++ b/src/phases/phase_spec_fetch_tests.cpp
@@ -819,7 +819,8 @@ struct user_managed_fixture {
   std::filesystem::path spec_file;
 
   explicit user_managed_fixture(std::string const &label) {
-    temp_dir = std::filesystem::temp_directory_path() / ("envy_test_user_managed_" + label);
+    temp_dir =
+        std::filesystem::temp_directory_path() / ("envy_test_user_managed_" + label);
     std::filesystem::create_directories(temp_dir);
     spec_file = temp_dir / "spec.lua";
   }

--- a/src/phases/phase_spec_fetch_tests.cpp
+++ b/src/phases/phase_spec_fetch_tests.cpp
@@ -122,21 +122,28 @@ TEST_CASE("string check without install errors") {
 
 TEST_CASE("user-managed package with check verb and FETCH function throws parse error") {
   expect_user_managed_cache_phase_error(
-      "FETCH", "function(install_dir, stage_dir, fetch_dir, tmp_dir) end", "_fn");
+      "FETCH",
+      "function(install_dir, stage_dir, fetch_dir, tmp_dir) end",
+      "_fn");
 }
 
 TEST_CASE("user-managed package with check verb and FETCH string throws parse error") {
-  expect_user_managed_cache_phase_error("FETCH", "\"https://example.com/x.tar.gz\"", "_str");
+  expect_user_managed_cache_phase_error("FETCH",
+                                        "\"https://example.com/x.tar.gz\"",
+                                        "_str");
 }
 
 TEST_CASE("user-managed package with check verb and FETCH table throws parse error") {
-  expect_user_managed_cache_phase_error(
-      "FETCH", "{ url = \"https://example.com/x.tar.gz\" }", "_tbl");
+  expect_user_managed_cache_phase_error("FETCH",
+                                        "{ url = \"https://example.com/x.tar.gz\" }",
+                                        "_tbl");
 }
 
 TEST_CASE("user-managed package with check verb and STAGE function throws parse error") {
   expect_user_managed_cache_phase_error(
-      "STAGE", "function(install_dir, stage_dir, fetch_dir, tmp_dir) end", "_fn");
+      "STAGE",
+      "function(install_dir, stage_dir, fetch_dir, tmp_dir) end",
+      "_fn");
 }
 
 TEST_CASE("user-managed package with check verb and STAGE string throws parse error") {
@@ -149,7 +156,9 @@ TEST_CASE("user-managed package with check verb and STAGE table throws parse err
 
 TEST_CASE("user-managed package with check verb and BUILD function throws parse error") {
   expect_user_managed_cache_phase_error(
-      "BUILD", "function(install_dir, stage_dir, fetch_dir, tmp_dir) end", "_fn");
+      "BUILD",
+      "function(install_dir, stage_dir, fetch_dir, tmp_dir) end",
+      "_fn");
 }
 
 TEST_CASE("user-managed package with check verb and BUILD string throws parse error") {

--- a/src/phases/phase_spec_fetch_tests.cpp
+++ b/src/phases/phase_spec_fetch_tests.cpp
@@ -51,7 +51,9 @@ void expect_user_managed_cache_phase_error(std::string const &phase_name) {
   {
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.check_" << phase_name << "@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = \"echo test\"\n";
+    ofs << "INSTALL = \"echo install\"\n";
     ofs << phase_name << " = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
   }
 
@@ -70,7 +72,7 @@ void expect_user_managed_cache_phase_error(std::string const &phase_name) {
   std::filesystem::remove_all(temp_dir);
 
   REQUIRE(exception_thrown);
-  CHECK(exception_msg.find("has CHECK verb (user-managed)") != std::string::npos);
+  CHECK(exception_msg.find("is user-managed (USER_MANAGED=true)") != std::string::npos);
   CHECK(exception_msg.find("declares " + phase_name + " phase") != std::string::npos);
 }
 
@@ -137,6 +139,7 @@ TEST_CASE("user-managed package with check verb and install phase succeeds") {
 
   std::ofstream ofs{ spec_file };
   ofs << "IDENTITY = \"test.check_install_ok@v1\"\n";
+  ofs << "USER_MANAGED = true\n";
   ofs << "CHECK = \"echo test\"\n";
   ofs << "INSTALL = \"echo install\"\n";
   ofs.close();
@@ -164,6 +167,7 @@ TEST_CASE("OPTIONS table succeeds and sees options") {
     std::ofstream ofs{ spec_file_ok };
     ofs << "IDENTITY = \"test.options_ok@v1\"\n";
     ofs << "OPTIONS = { foo = {} }\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function(project_root) return true end\n";
     ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
     ofs.close();
@@ -174,6 +178,7 @@ TEST_CASE("OPTIONS table succeeds and sees options") {
     std::ofstream ofs{ spec_file_true };
     ofs << "IDENTITY = \"test.options_true@v1\"\n";
     ofs << "OPTIONS = function(opts) return true end\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function(project_root) return true end\n";
     ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
     ofs.close();
@@ -201,6 +206,7 @@ TEST_CASE("OPTIONS function returns false fails") {
   std::ofstream ofs{ spec_file };
   ofs << "IDENTITY = \"test.options_false@v1\"\n";
   ofs << "OPTIONS = function(opts) return false end\n";
+  ofs << "USER_MANAGED = true\n";
   ofs << "CHECK = function(project_root) return true end\n";
   ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
   ofs.close();
@@ -234,6 +240,7 @@ TEST_CASE("OPTIONS function returns string fails with message") {
   std::ofstream ofs{ spec_file };
   ofs << "IDENTITY = \"test.options_string@v1\"\n";
   ofs << "OPTIONS = function(opts) return \"nope\" end\n";
+  ofs << "USER_MANAGED = true\n";
   ofs << "CHECK = function(project_root) return true end\n";
   ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
   ofs.close();
@@ -266,6 +273,7 @@ TEST_CASE("OPTIONS function invalid return type errors") {
   std::ofstream ofs{ spec_file };
   ofs << "IDENTITY = \"test.options_type@v1\"\n";
   ofs << "OPTIONS = function(opts) return 123 end\n";
+  ofs << "USER_MANAGED = true\n";
   ofs << "CHECK = function(project_root) return true end\n";
   ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
   ofs.close();
@@ -289,6 +297,7 @@ TEST_CASE("OPTIONS set to non-table non-function errors") {
   std::ofstream ofs{ spec_file };
   ofs << "IDENTITY = \"test.options_nonfn@v1\"\n";
   ofs << "OPTIONS = 42\n";
+  ofs << "USER_MANAGED = true\n";
   ofs << "CHECK = function(project_root) return true end\n";
   ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
   ofs.close();
@@ -312,6 +321,7 @@ TEST_CASE("OPTIONS function runtime error bubbles with context") {
   std::ofstream ofs{ spec_file };
   ofs << "IDENTITY = \"test.options_error@v1\"\n";
   ofs << "OPTIONS = function(opts) error(\"boom\") end\n";
+  ofs << "USER_MANAGED = true\n";
   ofs << "CHECK = function(project_root) return true end\n";
   ofs << "INSTALL = function(install_dir, stage_dir, fetch_dir, tmp_dir) end\n";
   ofs.close();
@@ -345,6 +355,7 @@ TEST_CASE("product name validation") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.product@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { [\"" << product_name << "\"] = \"/usr/bin/tool\" }\n";
@@ -370,6 +381,7 @@ TEST_CASE("product name validation") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.product@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { [\"" << lua_escaped_name << "\"] = \"/usr/bin/tool\" }\n";
@@ -423,6 +435,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = \"/usr/bin/tool\" }\n";
@@ -449,6 +462,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\", script = true } }\n";
@@ -475,6 +489,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { lib = { value = \"/usr/lib/libfoo.so\", script = false } }\n";
@@ -501,6 +516,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\" } }\n";
@@ -527,6 +543,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { lib = { script = false } }\n";
@@ -551,6 +568,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { lib = { value = 123 } }\n";
@@ -575,6 +593,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = {\n";
@@ -607,6 +626,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\", "
@@ -637,6 +657,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\" } }\n";
@@ -661,6 +682,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = \"/usr/bin/tool\" }\n";
@@ -685,6 +707,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\", "
@@ -710,6 +733,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\", "
@@ -735,6 +759,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = { tool = { value = \"/usr/bin/tool\", "
@@ -760,6 +785,7 @@ TEST_CASE("PRODUCTS table syntax") {
 
     std::ofstream ofs{ spec_file };
     ofs << "IDENTITY = \"test.products@v1\"\n";
+    ofs << "USER_MANAGED = true\n";
     ofs << "CHECK = function() return true end\n";
     ofs << "INSTALL = function() end\n";
     ofs << "PRODUCTS = {\n";
@@ -780,6 +806,256 @@ TEST_CASE("PRODUCTS table syntax") {
     CHECK(p->products.at("completer").platforms[1] == "linux");
     CHECK(p->products.at("lib").platforms.empty());
   }
+}
+
+// ============================================================================
+// USER_MANAGED top-level declaration tests
+// ============================================================================
+
+namespace {
+
+struct user_managed_fixture {
+  std::filesystem::path temp_dir;
+  std::filesystem::path spec_file;
+
+  explicit user_managed_fixture(std::string const &label) {
+    temp_dir = std::filesystem::temp_directory_path() / ("envy_test_user_managed_" + label);
+    std::filesystem::create_directories(temp_dir);
+    spec_file = temp_dir / "spec.lua";
+  }
+
+  ~user_managed_fixture() { std::filesystem::remove_all(temp_dir); }
+
+  void write(std::string const &body) {
+    std::ofstream ofs{ spec_file };
+    ofs << body;
+  }
+};
+
+}  // namespace
+
+TEST_CASE("USER_MANAGED=true with CHECK and INSTALL classifies user-managed") {
+  user_managed_fixture f{ "true_ok" };
+  f.write(
+      "IDENTITY = \"test.um_true_ok@v1\"\n"
+      "USER_MANAGED = true\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_true_ok@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  REQUIRE_NOTHROW(run_spec_fetch_phase(p, eng));
+  CHECK(p->type == pkg_type::USER_MANAGED);
+}
+
+TEST_CASE("USER_MANAGED=false with FETCH classifies cache-managed") {
+  user_managed_fixture f{ "false_fetch" };
+  f.write(
+      "IDENTITY = \"test.um_false_fetch@v1\"\n"
+      "USER_MANAGED = false\n"
+      "FETCH = function() end\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_false_fetch@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  REQUIRE_NOTHROW(run_spec_fetch_phase(p, eng));
+  CHECK(p->type == pkg_type::CACHE_MANAGED);
+}
+
+TEST_CASE("USER_MANAGED absent with FETCH defaults to cache-managed") {
+  user_managed_fixture f{ "absent_fetch" };
+  f.write(
+      "IDENTITY = \"test.um_absent@v1\"\n"
+      "FETCH = function() end\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_absent@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  REQUIRE_NOTHROW(run_spec_fetch_phase(p, eng));
+  CHECK(p->type == pkg_type::CACHE_MANAGED);
+}
+
+TEST_CASE("USER_MANAGED=true without CHECK throws") {
+  user_managed_fixture f{ "true_no_check" };
+  f.write(
+      "IDENTITY = \"test.um_true_no_check@v1\"\n"
+      "USER_MANAGED = true\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_true_no_check@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("must define 'CHECK'"));
+}
+
+TEST_CASE("USER_MANAGED=true without INSTALL throws") {
+  user_managed_fixture f{ "true_no_install" };
+  f.write(
+      "IDENTITY = \"test.um_true_no_install@v1\"\n"
+      "USER_MANAGED = true\n"
+      "CHECK = \"echo test\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_true_no_install@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("must define 'INSTALL'"));
+}
+
+TEST_CASE("USER_MANAGED=false with CHECK throws (forbidden combination)") {
+  user_managed_fixture f{ "false_with_check" };
+  f.write(
+      "IDENTITY = \"test.um_false_with_check@v1\"\n"
+      "USER_MANAGED = false\n"
+      "FETCH = function() end\n"
+      "CHECK = \"echo test\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_false_with_check@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("CHECK is only valid for user-managed packages"));
+}
+
+TEST_CASE("USER_MANAGED absent with CHECK throws") {
+  user_managed_fixture f{ "absent_with_check" };
+  f.write(
+      "IDENTITY = \"test.um_absent_check@v1\"\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_absent_check@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("CHECK is only valid for user-managed packages"));
+}
+
+TEST_CASE("USER_MANAGED function returning true classifies user-managed") {
+  user_managed_fixture f{ "fn_true" };
+  f.write(
+      "IDENTITY = \"test.um_fn_true@v1\"\n"
+      "USER_MANAGED = function() return true end\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_fn_true@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  REQUIRE_NOTHROW(run_spec_fetch_phase(p, eng));
+  CHECK(p->type == pkg_type::USER_MANAGED);
+}
+
+TEST_CASE("USER_MANAGED function returning false classifies cache-managed") {
+  user_managed_fixture f{ "fn_false" };
+  f.write(
+      "IDENTITY = \"test.um_fn_false@v1\"\n"
+      "USER_MANAGED = function() return false end\n"
+      "FETCH = function() end\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_fn_false@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  REQUIRE_NOTHROW(run_spec_fetch_phase(p, eng));
+  CHECK(p->type == pkg_type::CACHE_MANAGED);
+}
+
+TEST_CASE("USER_MANAGED function returning non-boolean throws") {
+  user_managed_fixture f{ "fn_nonbool" };
+  f.write(
+      "IDENTITY = \"test.um_fn_nonbool@v1\"\n"
+      "USER_MANAGED = function() return \"yes\" end\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_fn_nonbool@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("must return a boolean"));
+}
+
+TEST_CASE("USER_MANAGED function raising error throws with identity") {
+  user_managed_fixture f{ "fn_error" };
+  f.write(
+      "IDENTITY = \"test.um_fn_error@v1\"\n"
+      "USER_MANAGED = function() error(\"boom\") end\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_fn_error@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  bool threw{ false };
+  try {
+    run_spec_fetch_phase(p, eng);
+  } catch (std::runtime_error const &e) {
+    threw = true;
+    std::string const msg{ e.what() };
+    INFO(msg);
+    CHECK(msg.find("test.um_fn_error@v1") != std::string::npos);
+    CHECK(msg.find("boom") != std::string::npos);
+  }
+  CHECK(threw);
+}
+
+TEST_CASE("USER_MANAGED with non-boolean non-function type throws") {
+  user_managed_fixture f{ "bad_type" };
+  f.write(
+      "IDENTITY = \"test.um_bad_type@v1\"\n"
+      "USER_MANAGED = \"yes\"\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_bad_type@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("must be a boolean or function"));
+}
+
+TEST_CASE("USER_MANAGED=true with FETCH throws (cache-managed phase forbidden)") {
+  user_managed_fixture f{ "true_with_fetch" };
+  f.write(
+      "IDENTITY = \"test.um_true_fetch@v1\"\n"
+      "USER_MANAGED = true\n"
+      "CHECK = \"echo test\"\n"
+      "INSTALL = \"echo install\"\n"
+      "FETCH = function() end\n");
+
+  cache c;
+  engine eng{ c };
+  auto *cfg{ make_local_cfg("test.um_true_fetch@v1", f.spec_file) };
+  pkg *p{ eng.ensure_pkg(cfg) };
+
+  CHECK_THROWS_WITH(run_spec_fetch_phase(p, eng),
+                    doctest::Contains("declares FETCH phase"));
 }
 
 }  // namespace envy

--- a/src/resources/envy.lua
+++ b/src/resources/envy.lua
@@ -313,6 +313,18 @@ CHECK = nil
 ---@type table<string, envy.option_constraint>|fun(options: table): nil|boolean|string
 OPTIONS = nil
 
+---USER_MANAGED: marks the spec as user-managed (CHECK gates install; cache holds no install output).
+---Boolean or function returning a boolean (called once at spec load). Defaults to false (cache-managed).
+---When true, CHECK and INSTALL must be defined and FETCH/STAGE/BUILD must NOT be defined.
+---When false (default), CHECK must NOT be defined and FETCH must be defined.
+---@type boolean|fun(): boolean
+USER_MANAGED = nil
+
+---EXPORTABLE: cache-managed packages with EXPORTABLE=true expose their install output for export.
+---When false, only fetched bytes are preserved in the cache.
+---@type boolean
+EXPORTABLE = nil
+
 --------------------------------------------------------------------------------
 -- Manifest Globals
 --------------------------------------------------------------------------------

--- a/test_data/bundles/simple-bundle/specs/spec_a.lua
+++ b/test_data/bundles/simple-bundle/specs/spec_a.lua
@@ -1,4 +1,5 @@
 IDENTITY = "test.spec_a@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/bundles/simple-bundle/specs/spec_b.lua
+++ b/test_data/bundles/simple-bundle/specs/spec_b.lua
@@ -1,4 +1,5 @@
 IDENTITY = "test.spec_b@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/spec_util/empty_identity.lua
+++ b/test_data/spec_util/empty_identity.lua
@@ -1,5 +1,6 @@
 -- Spec with empty IDENTITY
 IDENTITY = ""
+USER_MANAGED = true
 
 function CHECK(project_root, options)
   return false

--- a/test_data/spec_util/missing_identity.lua
+++ b/test_data/spec_util/missing_identity.lua
@@ -1,3 +1,4 @@
+USER_MANAGED = true
 -- Spec without IDENTITY field
 DESCRIPTION = "This spec is missing IDENTITY"
 

--- a/test_data/spec_util/non_string_identity.lua
+++ b/test_data/spec_util/non_string_identity.lua
@@ -1,5 +1,6 @@
 -- Spec with IDENTITY that is not a string
 IDENTITY = 12345
+USER_MANAGED = true
 
 function CHECK(project_root, options)
   return false

--- a/test_data/spec_util/syntax_error.lua
+++ b/test_data/spec_util/syntax_error.lua
@@ -1,5 +1,6 @@
 -- Spec with syntax error
 IDENTITY = "test.syntax@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options
   -- missing closing paren

--- a/test_data/spec_util/uses_envy_globals.lua
+++ b/test_data/spec_util/uses_envy_globals.lua
@@ -1,5 +1,6 @@
 -- Test spec that uses envy globals at parse time
 IDENTITY = "test.uses_envy_globals@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 -- This requires envy table to be available at global scope

--- a/test_data/spec_util/valid_spec.lua
+++ b/test_data/spec_util/valid_spec.lua
@@ -1,5 +1,6 @@
 -- Simple valid spec with IDENTITY
 IDENTITY = "test.valid@v1"
+USER_MANAGED = true
 
 function CHECK(project_root, options)
   return false

--- a/test_data/specs/dependency_chain_gn.lua
+++ b/test_data/specs/dependency_chain_gn.lua
@@ -1,4 +1,5 @@
 IDENTITY = "local.gn@r0"
+USER_MANAGED = true
 CHECK = function() return true end
 INSTALL = function() end
 DEPENDENCIES = {

--- a/test_data/specs/simple_ninja.lua
+++ b/test_data/specs/simple_ninja.lua
@@ -1,4 +1,5 @@
 IDENTITY = "local.ninja@r0"
+USER_MANAGED = true
 CHECK = function() return true end
 INSTALL = function() end
 DEPENDENCIES = {

--- a/test_data/specs/simple_python.lua
+++ b/test_data/specs/simple_python.lua
@@ -1,3 +1,4 @@
 IDENTITY = "local.python@r0"
+USER_MANAGED = true
 CHECK = function() return true end
 INSTALL = function() end

--- a/test_data/specs/simple_uv.lua
+++ b/test_data/specs/simple_uv.lua
@@ -1,3 +1,4 @@
 IDENTITY = "local.uv@r0"
+USER_MANAGED = true
 CHECK = function() return true end
 INSTALL = function() end

--- a/test_data/specs/string_check_install.lua
+++ b/test_data/specs/string_check_install.lua
@@ -1,4 +1,5 @@
 -- Test spec with string CHECK and INSTALL (user-managed)
 IDENTITY = "local.string_check_install@v1"
+USER_MANAGED = true
 CHECK = "echo checking"
 INSTALL = "echo installing"

--- a/test_data/specs/string_check_only.lua
+++ b/test_data/specs/string_check_only.lua
@@ -1,3 +1,4 @@
 -- Test spec with string CHECK but no INSTALL (should error)
 IDENTITY = "local.string_check_only@v1"
+USER_MANAGED = true
 CHECK = "echo checking"

--- a/test_data/specs/weak_branch_one.lua
+++ b/test_data/specs/weak_branch_one.lua
@@ -1,5 +1,6 @@
 -- Fallback that creates a shared dependency
 IDENTITY = "local.branch_one@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.shared", weak = { spec = "local.shared@v1", source = "weak_shared.lua" } },
 }

--- a/test_data/specs/weak_branch_two.lua
+++ b/test_data/specs/weak_branch_two.lua
@@ -1,5 +1,6 @@
 -- Second fallback that depends on the same shared target
 IDENTITY = "local.branch_two@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.shared", weak = { spec = "local.shared@v1", source = "weak_shared.lua" } },
 }

--- a/test_data/specs/weak_chain_b.lua
+++ b/test_data/specs/weak_chain_b.lua
@@ -1,5 +1,6 @@
 -- Fallback that itself carries a weak reference
 IDENTITY = "local.chain_b@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.chain_c", weak = { spec = "local.chain_c@v1", source = "weak_chain_c.lua" } },
 }

--- a/test_data/specs/weak_chain_c.lua
+++ b/test_data/specs/weak_chain_c.lua
@@ -1,5 +1,6 @@
 -- Terminal dependency for the weak chain
 IDENTITY = "local.chain_c@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_chain_root.lua
+++ b/test_data/specs/weak_chain_root.lua
@@ -1,5 +1,6 @@
 -- Weak reference whose fallback introduces another weak reference (multi-iteration)
 IDENTITY = "local.weak_chain_root@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.chain_missing", weak = { spec = "local.chain_b@v1", source = "weak_chain_b.lua" } },
 }

--- a/test_data/specs/weak_consumer_ambiguous.lua
+++ b/test_data/specs/weak_consumer_ambiguous.lua
@@ -1,5 +1,6 @@
 -- Reference-only dependency that matches multiple strong candidates
 IDENTITY = "local.weak_consumer_ambiguous@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.dupe@v1", source = "weak_dupe_v1.lua" },
   { spec = "local.dupe@v2", source = "weak_dupe_v2.lua" },

--- a/test_data/specs/weak_consumer_existing.lua
+++ b/test_data/specs/weak_consumer_existing.lua
@@ -1,5 +1,6 @@
 -- Weak dependency with a present strong match and unused fallback
 IDENTITY = "local.weak_consumer_existing@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.existing_dep@v1", source = "weak_existing_dep.lua" },
   { spec = "local.existing_dep", weak = { spec = "local.unused_fallback@v1", source = "weak_unused_fallback.lua" } },

--- a/test_data/specs/weak_consumer_fallback.lua
+++ b/test_data/specs/weak_consumer_fallback.lua
@@ -1,5 +1,6 @@
 -- Weak dependency with fallback when the target is absent
 IDENTITY = "local.weak_consumer_fallback@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.missing_dep", weak = { spec = "local.weak_fallback@v1", source = "weak_fallback.lua" } },
 }

--- a/test_data/specs/weak_consumer_ref_only.lua
+++ b/test_data/specs/weak_consumer_ref_only.lua
@@ -1,5 +1,6 @@
 -- Reference-only dependency that is satisfied by an existing provider
 IDENTITY = "local.weak_consumer_ref_only@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.weak_provider@v1", source = "weak_provider.lua" },
   { spec = "local.weak_provider" },

--- a/test_data/specs/weak_dupe_v1.lua
+++ b/test_data/specs/weak_dupe_v1.lua
@@ -1,5 +1,6 @@
 -- First candidate for ambiguity tests
 IDENTITY = "local.dupe@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_dupe_v2.lua
+++ b/test_data/specs/weak_dupe_v2.lua
@@ -1,5 +1,6 @@
 -- Second candidate for ambiguity tests
 IDENTITY = "local.dupe@v2"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_existing_dep.lua
+++ b/test_data/specs/weak_existing_dep.lua
@@ -1,5 +1,6 @@
 -- Strong dependency that should satisfy weak queries
 IDENTITY = "local.existing_dep@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_fallback.lua
+++ b/test_data/specs/weak_fallback.lua
@@ -1,5 +1,6 @@
 -- Fallback spec used when no provider is found
 IDENTITY = "local.weak_fallback@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_missing_ref.lua
+++ b/test_data/specs/weak_missing_ref.lua
@@ -1,5 +1,6 @@
 -- Reference-only dependency with no provider anywhere in the graph
 IDENTITY = "local.weak_missing_ref@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.never_provided" },
 }

--- a/test_data/specs/weak_progress_flat_root.lua
+++ b/test_data/specs/weak_progress_flat_root.lua
@@ -1,5 +1,6 @@
 -- Two weak fallbacks that each introduce new weak references; unresolved count stays flat
 IDENTITY = "local.weak_progress_flat_root@v1"
+USER_MANAGED = true
 DEPENDENCIES = {
   { spec = "local.branch_one", weak = { spec = "local.branch_one@v1", source = "weak_branch_one.lua" } },
   { spec = "local.branch_two", weak = { spec = "local.branch_two@v1", source = "weak_branch_two.lua" } },

--- a/test_data/specs/weak_provider.lua
+++ b/test_data/specs/weak_provider.lua
@@ -1,5 +1,6 @@
 -- Provides a concrete spec for weak/reference consumers
 IDENTITY = "local.weak_provider@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_shared.lua
+++ b/test_data/specs/weak_shared.lua
@@ -1,5 +1,6 @@
 -- Shared dependency produced by fallbacks
 IDENTITY = "local.shared@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)

--- a/test_data/specs/weak_unused_fallback.lua
+++ b/test_data/specs/weak_unused_fallback.lua
@@ -1,5 +1,6 @@
 -- Fallback that should be ignored when a strong match exists
 IDENTITY = "local.unused_fallback@v1"
+USER_MANAGED = true
 DEPENDENCIES = {}
 
 function CHECK(project_root, options)


### PR DESCRIPTION
## Summary

Replaces the implicit "CHECK presence implies user-managed" detection with an explicit top-level `USER_MANAGED` (boolean or function returning boolean, mirroring `EXPORTABLE`). `CHECK` becomes an ordinary phase verb that is only legal when `USER_MANAGED=true`; validation enforces that user-managed specs declare `CHECK`+`INSTALL` (no `FETCH`/`STAGE`/`BUILD`) and cache-managed specs declare `FETCH` (no `CHECK`). All existing specs that defined `CHECK` (3 examples, 27 test_data fixtures, 22 functional test files) gain `USER_MANAGED = true`; docs and `src/resources/envy.lua` describe the new global. This unblocks a follow-up change (`cache_key = false` per-option flag) that needs cache-managed packages to be able to adopt `CHECK` without silently flipping lifecycle semantics.

## Test plan

- [x] `./build.sh` — 1043 unit tests pass
- [x] `python3.13 -m functional_tests` — 900 tests pass (63 pre-existing skips)
- [x] New tests cover boolean/function/error/forbidden-combination cases in `phase_spec_fetch_tests.cpp` and `test_user_managed.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)