### PR TITLE
fix: use native curl.exe/tar.exe in Windows bootstrap, not PowerShell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,10 @@ jobs:
       - name: Build
         shell: powershell
         run: |
-          &"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch ${{ matrix.arch }} -HostArch amd64
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -property installationPath
+          if (-not $vsPath) { throw "Visual Studio installation not found via vswhere" }
+          & "$vsPath\Common7\Tools\Launch-VsDevShell.ps1" -Arch ${{ matrix.arch }} -HostArch amd64
           $BuildArgs = "${{ matrix.build_args }}"
           $Arguments = @()
           if (-not [string]::IsNullOrWhiteSpace($BuildArgs)) {

--- a/docs/envy-init.md
+++ b/docs/envy-init.md
@@ -258,7 +258,7 @@ cd my-project
 
 # What happens:
 #   - Bootstrap reads @envy version from envy.lua
-#   - Checks ~/Library/Caches/envy/1.2.3/envy
+#   - Checks ~/Library/Caches/envy/envy/1.2.3/envy
 #   - Not found → downloads from GitHub releases
 #   - Caches binary
 #   - Executes: envy sync
@@ -289,7 +289,7 @@ Alice wants to upgrade from 1.2.3 to 1.4.0:
 #   - Bootstrap reads @envy version "1.4.0"
 #   - Checks cache for 1.4.0 → not found
 #   - Downloads envy 1.4.0
-#   - Caches at ~/Library/Caches/envy/1.4.0/envy
+#   - Caches at ~/Library/Caches/envy/envy/1.4.0/envy
 #   - Old 1.2.3 remains in cache (no deletion)
 #   - Executes: envy sync
 

--- a/docs/envy-init.md
+++ b/docs/envy-init.md
@@ -185,15 +185,15 @@ Two platform-specific scripts—no polyglot tricks. Each is idiomatic for its pl
 
 ### Unix Script (`envy`)
 
-Location: `src/envy-init/envy`
+Location: `src/resources/envy`
 
 Bash script optimized for minimal subprocess overhead. Parses all directives in a single `head | sed` pipeline (2 subprocesses) with bash string replacement for unescaping. Downloads via `curl`.
 
 ### Windows Script (`envy.bat`)
 
-Location: `src/envy-init/envy.bat`
+Location: `src/resources/envy.bat`
 
-Pure batch implementation for directive parsing—avoids ~100-200ms PowerShell startup overhead on every invocation. Downloads via PowerShell `Invoke-WebRequest`.
+Pure batch implementation for directive parsing—avoids ~100-200ms PowerShell startup overhead on every invocation. Downloads with native `curl.exe` and extracts the `.zip` with native `tar.exe` (bsdtar); both ship in `System32` on Windows 10 1803+ and are immune to PowerShell policy. PowerShell `Invoke-WebRequest`/`Expand-Archive` are kept only as a fallback for older Windows—avoided on the primary path because `Expand-Archive`'s module (`Microsoft.PowerShell.Archive`) can be blocked by machine policy (WDAC/AppLocker constrained-language mode) even while compiled binaries still run.
 
 **Limitation:** Values containing `!` or `\"` escape sequences are not supported. Batch's delayed expansion interprets `!` as variable delimiters; `\"` escapes are difficult to process correctly. These edge cases are rare (version strings, paths, and URLs typically don't contain these characters).
 
@@ -258,7 +258,7 @@ cd my-project
 
 # What happens:
 #   - Bootstrap reads @envy version from envy.lua
-#   - Checks ~/Library/Caches/envy/bin/1.2.3/envy
+#   - Checks ~/Library/Caches/envy/1.2.3/envy
 #   - Not found → downloads from GitHub releases
 #   - Caches binary
 #   - Executes: envy sync
@@ -289,7 +289,7 @@ Alice wants to upgrade from 1.2.3 to 1.4.0:
 #   - Bootstrap reads @envy version "1.4.0"
 #   - Checks cache for 1.4.0 → not found
 #   - Downloads envy 1.4.0
-#   - Caches at ~/Library/Caches/envy/bin/1.4.0/envy
+#   - Caches at ~/Library/Caches/envy/1.4.0/envy
 #   - Old 1.2.3 remains in cache (no deletion)
 #   - Executes: envy sync
 
@@ -605,12 +605,12 @@ The fallback version is whatever envy created this bootstrap script—a reasonab
 Phase 1 delivers complete `@envy` directive parsing in both bootstrap scripts and the envy runtime. The result: new comment-metadata manifests are fully parsed by all consumers.
 
 **Bootstrap scripts:**
-- [x] Create `src/envy-init/envy` - bash script template
-- [x] Create `src/envy-init/envy.bat` - batch script template
+- [x] Create `src/resources/envy` - bash script template
+- [x] Create `src/resources/envy.bat` - batch script template
 - [x] Implement directive parsing (optimized single-pass sed for bash, pure batch for Windows)
 - [x] Implement fallback to `FALLBACK_VERSION` with warning when `@envy version` missing
 - [x] Implement cache resolution (env > manifest > default)
-- [x] Implement platform/arch detection (Unix only; Windows assumes x86_64)
+- [x] Implement platform/arch detection (Unix and Windows; both detect x86_64/arm64)
 - [x] Implement download with curl
 - [x] Implement error handling and user feedback
 
@@ -644,10 +644,10 @@ This validates the full bootstrap pipeline: parse → download → cache → exe
 
 - [x] Create `cmake/scripts/embed_resource.py`
 - [x] Create `cmake/EmbedResource.cmake`
-- [x] Embed `src/envy-init/envy.lua` (lua_ls type definitions)
-- [x] Embed `src/envy-init/manifest_template.lua`
-- [x] Embed `src/envy-init/envy` (Unix only)
-- [x] Embed `src/envy-init/envy.bat` (Windows only)
+- [x] Embed `src/resources/envy.lua` (lua_ls type definitions)
+- [x] Embed `src/resources/manifest_template.lua`
+- [x] Embed `src/resources/envy` (Unix only)
+- [x] Embed `src/resources/envy.bat` (Windows only)
 - [x] Update CMakeLists.txt (platform-conditional embedding)
 
 ### Phase 3: Runtime Support
@@ -717,7 +717,7 @@ Envy self-deploys to cache on startup (before any command runs). Uses `platform:
 ## Files to Create
 
 ```
-src/envy-init/
+src/resources/
 ├── envy                      # Bash bootstrap template ✓
 ├── envy.bat                  # Batch bootstrap template ✓
 ├── envy.lua                  # lua_ls type definitions ✓
@@ -854,9 +854,9 @@ Added 10 tests for `expand_path()` and `resolve_cache_root()` covering tilde exp
 
 **Phase E: Bootstrap script path expansion** ✓
 
-Unix (`src/envy-init/envy`): Expands `~` to `$HOME` and uses `eval` for `$VAR`/`${VAR}` expansion.
+Unix (`src/resources/envy`): Expands `~` to `$HOME` and uses `eval` for `$VAR`/`${VAR}` expansion.
 
-Windows (`src/envy-init/envy.bat`): Expands `~` to `%USERPROFILE%`. Note: `$VAR` expansion not supported on Windows; use full paths or `%VAR%` syntax.
+Windows (`src/resources/envy.bat`): Expands `~` to `%USERPROFILE%`. Note: `$VAR` expansion not supported on Windows; use full paths or `%VAR%` syntax.
 
 **Phase G: Functional tests** ✓
 

--- a/functional_tests/test_bootstrap.py
+++ b/functional_tests/test_bootstrap.py
@@ -221,12 +221,18 @@ class BootstrapIntegrationTest(unittest.TestCase):
         return bootstrap_dest
 
     def _run_bootstrap(
-        self, bootstrap_script: Path, args: list[str], cache_dir: Path | None = None
+        self,
+        bootstrap_script: Path,
+        args: list[str],
+        cache_dir: Path | None = None,
+        env_overrides: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         """Run the bootstrap script and return the result."""
         env = os.environ.copy()
         env["ENVY_MIRROR"] = f"http://127.0.0.1:{self._port}"
         env["ENVY_CACHE_ROOT"] = str(cache_dir or self._temp_dir / "cache")
+        if env_overrides:
+            env.update(env_overrides)
 
         if sys.platform == "win32":
             cmd = ["cmd.exe", "/c", str(bootstrap_script), *args]
@@ -250,6 +256,43 @@ class BootstrapIntegrationTest(unittest.TestCase):
         self.assertEqual(0, result.returncode, f"stderr: {result.stderr}")
         # envy version outputs to stderr
         self.assertIn("envy version", result.stderr)
+
+    @unittest.skipUnless(
+        sys.platform == "win32",
+        "exercises the Windows envy.bat native curl.exe/tar.exe path",
+    )
+    def test_bootstrap_succeeds_without_powershell(self) -> None:
+        """Bootstrap must not depend on PowerShell to download and extract.
+
+        Machine policy (WDAC/AppLocker constrained-language mode, disabled module
+        autoloading, a tampered PSModulePath) can block the Microsoft.PowerShell.Archive
+        script module that `Expand-Archive` lives in, while compiled binaries still run.
+        The bootstrap prefers native curl.exe/tar.exe; PowerShell is only a fallback.
+        Shadow `powershell`/`pwsh` with always-failing stubs earlier in PATH (a tripwire:
+        any PowerShell use in the happy path would fail the operation) and assert the
+        bootstrap still downloads, extracts, and execs.
+        """
+        bootstrap = self._setup_test_project("simple.lua")
+
+        sabotage = self._temp_dir / "sabotage"
+        sabotage.mkdir()
+        for name in ("powershell.bat", "pwsh.bat"):
+            (sabotage / name).write_text(
+                "@echo PowerShell blocked by policy (test) 1>&2\r\n@exit /b 1\r\n"
+            )
+        scrubbed_path = f"{sabotage}{os.pathsep}{os.environ.get('PATH', '')}"
+
+        result = self._run_bootstrap(
+            bootstrap, ["version"], env_overrides={"PATH": scrubbed_path}
+        )
+
+        self.assertEqual(0, result.returncode, f"stderr: {result.stderr}")
+        self.assertIn("envy version", result.stderr)
+        # Confirms the download happened over the network (via curl.exe), not a cache hit.
+        self.assertTrue(
+            any(p.endswith(".zip") for p in self._server.request_paths),
+            f"expected a .zip download request, got: {self._server.request_paths}",
+        )
 
     def test_bootstrap_caches_binary(self) -> None:
         """Test that bootstrap uses cached binary when present."""

--- a/src/resources/envy.bat
+++ b/src/resources/envy.bat
@@ -81,6 +81,15 @@ if "!VERSION!"=="" (
         )
     )
     if "!VERSION!"=="" (
+        REM Prefer native curl.exe (policy-resistant); parse the redirect's trailing tag.
+        set "REDIR="
+        where /q curl.exe && for /f "usebackq tokens=*" %%u in (`curl.exe -fsS -o nul -w "%%{redirect_url}" "https://github.com/charlesnicholson/envy/releases/latest" 2^>nul`) do set "REDIR=%%u"
+        if defined REDIR set "REDIR=!REDIR:/=\!"
+        if defined REDIR for %%a in ("!REDIR!") do set "TAG=%%~nxa"
+        if defined TAG set "VERSION=!TAG!"
+        if defined TAG if "!TAG:~0,1!"=="v" set "VERSION=!TAG:~1!"
+    )
+    if "!VERSION!"=="" (
         for /f "tokens=*" %%u in ('powershell -NoProfile -Command "$ProgressPreference='SilentlyContinue'; try { $r=[System.Net.WebRequest]::Create('https://github.com/charlesnicholson/envy/releases/latest'); $r.AllowAutoRedirect=$false; $h=$r.GetResponse().Headers['Location']; if($h){($h -split '/')[-1] -replace '^v',''} } catch {}" 2^>nul') do set "VERSION=%%u"
     )
     if "!VERSION!"=="" set "VERSION=!FALLBACK_VERSION!"
@@ -96,12 +105,25 @@ echo Downloading envy !VERSION!... >&2
 set "URL=!ENVY_MIRROR!/v!VERSION!/envy-windows-!ARCH!.zip"
 REM Escape single quotes for PowerShell (replace ' with '')
 set "SAFE_URL=!URL:'=''!"
-for /f %%i in ('powershell -NoProfile -Command "[System.IO.Path]::GetRandomFileName()"') do set "TEMP_DIR=!TEMP!\envy-%%i"
+set "TEMP_DIR=!TEMP!\envy-%RANDOM%%RANDOM%"
 set "TEMP_ZIP=!TEMP_DIR!.zip"
-powershell -NoProfile -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '!SAFE_URL!' -OutFile '!TEMP_ZIP!' -UseBasicParsing"
-if errorlevel 1 (echo ERROR: Failed to download envy from !URL! >&2 & del "!TEMP_ZIP!" 2>nul & exit /b 1)
-powershell -NoProfile -Command "$ProgressPreference='SilentlyContinue'; Expand-Archive -Path '!TEMP_ZIP!' -DestinationPath '!TEMP_DIR!' -Force"
-if errorlevel 1 (echo ERROR: Failed to extract envy >&2 & del "!TEMP_ZIP!" 2>nul & exit /b 1)
+mkdir "!TEMP_DIR!" 2>nul
+
+REM Download: prefer native curl.exe (policy-resistant), fall back to PowerShell.
+set "OK="
+where /q curl.exe && (curl.exe -fsSL "!URL!" -o "!TEMP_ZIP!" && set "OK=1")
+if not defined OK (
+    powershell -NoProfile -Command "$ProgressPreference='SilentlyContinue'; Invoke-WebRequest -Uri '!SAFE_URL!' -OutFile '!TEMP_ZIP!' -UseBasicParsing" && set "OK=1"
+)
+if not defined OK (echo ERROR: Failed to download envy from !URL! >&2 & rmdir /s /q "!TEMP_DIR!" 2>nul & del "!TEMP_ZIP!" 2>nul & exit /b 1)
+
+REM Extract: prefer native tar.exe (bsdtar reads zip), fall back to PowerShell Expand-Archive.
+set "OK="
+where /q tar.exe && (tar.exe -xf "!TEMP_ZIP!" -C "!TEMP_DIR!" && set "OK=1")
+if not defined OK (
+    powershell -NoProfile -Command "$ProgressPreference='SilentlyContinue'; Expand-Archive -Path '!TEMP_ZIP!' -DestinationPath '!TEMP_DIR!' -Force" && set "OK=1"
+)
+if not defined OK (echo ERROR: Failed to extract envy >&2 & del "!TEMP_ZIP!" 2>nul & exit /b 1)
 del "!TEMP_ZIP!" 2>nul
 set "ENVY_BIN=!TEMP_DIR!\envy.exe"
 

--- a/src/resources/envy.bat
+++ b/src/resources/envy.bat
@@ -83,6 +83,7 @@ if "!VERSION!"=="" (
     if "!VERSION!"=="" (
         REM Prefer native curl.exe (policy-resistant); parse the redirect's trailing tag.
         set "REDIR="
+        set "TAG="
         where /q curl.exe && for /f "usebackq tokens=*" %%u in (`curl.exe -fsS -o nul -w "%%{redirect_url}" "https://github.com/charlesnicholson/envy/releases/latest" 2^>nul`) do set "REDIR=%%u"
         if defined REDIR set "REDIR=!REDIR:/=\!"
         if defined REDIR for %%a in ("!REDIR!") do set "TAG=%%~nxa"
@@ -123,7 +124,7 @@ where /q tar.exe && (tar.exe -xf "!TEMP_ZIP!" -C "!TEMP_DIR!" && set "OK=1")
 if not defined OK (
     powershell -NoProfile -Command "$ProgressPreference='SilentlyContinue'; Expand-Archive -Path '!TEMP_ZIP!' -DestinationPath '!TEMP_DIR!' -Force" && set "OK=1"
 )
-if not defined OK (echo ERROR: Failed to extract envy >&2 & del "!TEMP_ZIP!" 2>nul & exit /b 1)
+if not defined OK (echo ERROR: Failed to extract envy >&2 & rmdir /s /q "!TEMP_DIR!" 2>nul & del "!TEMP_ZIP!" 2>nul & exit /b 1)
 del "!TEMP_ZIP!" 2>nul
 set "ENVY_BIN=!TEMP_DIR!\envy.exe"
 

--- a/src/resources/envy.bat
+++ b/src/resources/envy.bat
@@ -106,9 +106,17 @@ echo Downloading envy !VERSION!... >&2
 set "URL=!ENVY_MIRROR!/v!VERSION!/envy-windows-!ARCH!.zip"
 REM Escape single quotes for PowerShell (replace ' with '')
 set "SAFE_URL=!URL:'=''!"
+REM Claim a unique temp dir via atomic mkdir (cmd's %RANDOM% can collide across
+REM concurrent bootstraps; mkdir succeeds for exactly one owner of a given name).
+set /a TEMP_TRIES=0
+:mktemp
 set "TEMP_DIR=!TEMP!\envy-%RANDOM%%RANDOM%"
+mkdir "!TEMP_DIR!" 2>nul && goto :gottemp
+set /a TEMP_TRIES+=1
+if !TEMP_TRIES! LSS 10 goto :mktemp
+echo ERROR: Could not create a temp directory under !TEMP! >&2 & exit /b 1
+:gottemp
 set "TEMP_ZIP=!TEMP_DIR!.zip"
-mkdir "!TEMP_DIR!" 2>nul
 
 REM Download: prefer native curl.exe (policy-resistant), fall back to PowerShell.
 set "OK="


### PR DESCRIPTION
On a clean Windows machine the bootstrap failed at `Expand-Archive`, whose `Microsoft.PowerShell.Archive` script module can be blocked by machine policy (WDAC/AppLocker constrained-language mode, disabled module autoloading, or a tampered `PSModulePath`) even while compiled cmdlets like `Invoke-WebRequest` still run. `src/resources/envy.bat` now downloads with native `curl.exe` and extracts with native `tar.exe` (bsdtar reads zip; both in `System32` since Win10 1803), keeping PowerShell `Invoke-WebRequest`/`Expand-Archive` only as a fallback for older Windows, and also drops the `GetRandomFileName`/.NET temp-name call and moves the latest-version probe to curl. Adds a Windows-only regression test (`test_bootstrap_succeeds_without_powershell`) that shadows `powershell`/`pwsh` with failing stubs and asserts the bootstrap still downloads/extracts/execs, and refreshes `docs/envy-init.md` (download/extract mechanism, the `src/resources/` script path, cache layout, Windows arch detection). Verified with `./build.sh` (1048 unit tests pass) and the functional suite (901 run, 0 failed); the Windows path runs end-to-end on the `windows-latest`/`windows-11-arm` CI runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
