### PR TITLE
fix: PowerShell hook re-detects UTF-8; nudge when raccoon icon hidden

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -54,3 +54,5 @@ All three are independent—combine as needed.
 **Temporarily disable:** `export ENVY_SHELL_HOOK_DISABLE=1` (unset to re-enable).
 
 **Force refresh:** Delete `$CACHE/shell/` and run any envy command.
+
+**Missing raccoon (Windows/PowerShell):** The icon needs a UTF-8 console; PowerShell defaults to the legacy OEM code page (e.g. 437). Add `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()` *above* the hook `source` line in `$PROFILE`. The hook nudges once per session when the icon is wanted but the console isn't UTF-8—silenced by `ENVY_SHELL_NO_ICON=1`.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -55,4 +55,4 @@ All three are independent—combine as needed.
 
 **Force refresh:** Delete `$CACHE/shell/` and run any envy command.
 
-**Missing raccoon (Windows/PowerShell):** The icon needs a UTF-8 console; PowerShell defaults to the legacy OEM code page (e.g. 437). Add `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()` *above* the hook `source` line in `$PROFILE`. The hook nudges once per session when the icon is wanted but the console isn't UTF-8—silenced by `ENVY_SHELL_NO_ICON=1`.
+**Missing raccoon (Windows/PowerShell):** The icon needs a UTF-8 console; PowerShell defaults to the legacy OEM code page (e.g. 437). Add `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()` *above* the line that dot-sources the hook (`. "..."`) in `$PROFILE`. The hook nudges once per session when the icon is wanted but the console isn't UTF-8—silenced by `ENVY_SHELL_NO_ICON=1`.

--- a/functional_tests/test_shell_hook.py
+++ b/functional_tests/test_shell_hook.py
@@ -1362,8 +1362,8 @@ class TestPowerShellHook(unittest.TestCase):
 
     # --- v6: one-time UTF-8 capability hint ---
 
-    def test_utf8_hint_shown_when_icon_wanted_but_console_not_utf8(self) -> None:
-        """Non-UTF-8 console + icon wanted: nudge once explaining why it's hidden."""
+    def test_utf8_hint_shown_once_when_icon_wanted_but_console_not_utf8(self) -> None:
+        """Non-UTF-8 console + icon wanted: nudge exactly once per session, not on every entry."""
         project = self._make_envy_project("ps-utf8-hint")
         result = self._run_pwsh_hook_test(
             f"$env:LANG = ''; $env:LC_ALL = ''; $env:LC_CTYPE = ''\n"
@@ -1372,10 +1372,17 @@ class TestPowerShellHook(unittest.TestCase):
             f'Set-Location "{project}"\n'
             f"$global:_ENVY_LAST_PWD = $null\n"
             f"_envy_hook\n"
+            f'Set-Location "{self._temp_dir}"\n'
+            f"$global:_ENVY_LAST_PWD = $null\n"
+            f"_envy_hook\n"
+            f'Set-Location "{project}"\n'
+            f"$global:_ENVY_LAST_PWD = $null\n"
+            f"_envy_hook\n"
         )
         self.assertEqual(0, result.returncode, f"stderr: {result.stderr}")
         combined = result.stdout + result.stderr
-        self.assertIn("raccoon icon hidden", combined)
+        # Entered twice (with a leave between), but the nudge fires only once.
+        self.assertEqual(1, combined.count("raccoon icon hidden"))
         self.assertIn("UTF8Encoding", combined)
 
     def test_utf8_hint_suppressed_when_icon_disabled(self) -> None:

--- a/functional_tests/test_shell_hook.py
+++ b/functional_tests/test_shell_hook.py
@@ -1360,6 +1360,40 @@ class TestPowerShellHook(unittest.TestCase):
         self.assertIn("envy: entering", combined)
         self.assertNotIn("\U0001f99d", combined)
 
+    # --- v6: one-time UTF-8 capability hint ---
+
+    def test_utf8_hint_shown_when_icon_wanted_but_console_not_utf8(self) -> None:
+        """Non-UTF-8 console + icon wanted: nudge once explaining why it's hidden."""
+        project = self._make_envy_project("ps-utf8-hint")
+        result = self._run_pwsh_hook_test(
+            f"$env:LANG = ''; $env:LC_ALL = ''; $env:LC_CTYPE = ''\n"
+            f"[Console]::OutputEncoding = [System.Text.Encoding]::ASCII\n"
+            f'. "{self._hook_path}"\n'
+            f'Set-Location "{project}"\n'
+            f"$global:_ENVY_LAST_PWD = $null\n"
+            f"_envy_hook\n"
+        )
+        self.assertEqual(0, result.returncode, f"stderr: {result.stderr}")
+        combined = result.stdout + result.stderr
+        self.assertIn("raccoon icon hidden", combined)
+        self.assertIn("UTF8Encoding", combined)
+
+    def test_utf8_hint_suppressed_when_icon_disabled(self) -> None:
+        """ENVY_SHELL_NO_ICON=1 means the icon is unwanted — never nudge about it."""
+        project = self._make_envy_project("ps-utf8-hint-off")
+        result = self._run_pwsh_hook_test(
+            f'$env:ENVY_SHELL_NO_ICON = "1"\n'
+            f"$env:LANG = ''; $env:LC_ALL = ''; $env:LC_CTYPE = ''\n"
+            f"[Console]::OutputEncoding = [System.Text.Encoding]::ASCII\n"
+            f'. "{self._hook_path}"\n'
+            f'Set-Location "{project}"\n'
+            f"$global:_ENVY_LAST_PWD = $null\n"
+            f"_envy_hook\n"
+        )
+        self.assertEqual(0, result.returncode, f"stderr: {result.stderr}")
+        combined = result.stdout + result.stderr
+        self.assertNotIn("raccoon icon hidden", combined)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/resources/shell_hook.ps1
+++ b/src/resources/shell_hook.ps1
@@ -1,10 +1,14 @@
 # envy shell hook — managed by envy; do not edit
 $global:_ENVY_HOOK_VERSION = @@ENVY_HOOK_VERSION@@
 
-# Detect UTF-8 locale for emoji/unicode output
-$global:_ENVY_UTF8 = (($env:LC_ALL + $env:LC_CTYPE + $env:LANG) -match '[Uu][Tt][Ff]-?8') -or
-    $(try { [Console]::OutputEncoding.WebName -eq 'utf-8' } catch { $false })
-$global:_ENVY_DASH = if ($global:_ENVY_UTF8) { "`u{2014}" } else { "--" }
+# Detect UTF-8 capability for emoji/unicode output. Re-evaluated on every prompt
+# (cheap) so flipping the console encoding takes effect without re-sourcing.
+function _envy_detect_utf8 {
+    $global:_ENVY_UTF8 = (($env:LC_ALL + $env:LC_CTYPE + $env:LANG) -match '[Uu][Tt][Ff]-?8') -or
+        $(try { [Console]::OutputEncoding.WebName -eq 'utf-8' } catch { $false })
+    $global:_ENVY_DASH = if ($global:_ENVY_UTF8) { "`u{2014}" } else { "--" }
+}
+_envy_detect_utf8
 
 function _envy_find_manifest {
     $d = (Get-Location).Path
@@ -41,6 +45,8 @@ function _envy_parse_bin($manifestDir) {
 function _envy_hook {
     if ($env:ENVY_SHELL_HOOK_DISABLE -eq "1") { return }
 
+    _envy_detect_utf8
+
     $currentDir = (Get-Location).Path
     if ($currentDir -eq $global:_ENVY_LAST_PWD) { return }
     $global:_ENVY_LAST_PWD = $currentDir
@@ -72,6 +78,14 @@ function _envy_hook {
                         [Console]::Error.WriteLine("envy: entering $newName $($global:_ENVY_DASH) tools added to PATH")
                     }
                     $global:_ENVY_PROMPT_ACTIVE = $true
+                    # One-time nudge: the icon is wanted (NO_ICON unset) but the
+                    # console can't render it. Never shown if the user opted out.
+                    if (-not $global:_ENVY_UTF8 -and
+                        $env:ENVY_SHELL_NO_ICON -ne "1" -and
+                        -not $global:_ENVY_UTF8_HINTED) {
+                        $global:_ENVY_UTF8_HINTED = $true
+                        [Console]::Error.WriteLine("envy: raccoon icon hidden -- console is not UTF-8. Add [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new() above the hook line in your profile, or set ENVY_SHELL_NO_ICON=1 to silence.")
+                    }
                 }
                 $env:ENVY_PROJECT_ROOT = $manifestDir
                 return
@@ -98,6 +112,7 @@ function _envy_hook {
 $global:_ENVY_LAST_PWD = $null
 $global:_ENVY_BIN_DIR = $null
 $global:_ENVY_PROMPT_ACTIVE = $false
+$global:_ENVY_UTF8_HINTED = $false
 
 if (-not (Test-Path Function:\global:_envy_original_prompt)) {
     Copy-Item Function:\prompt Function:\global:_envy_original_prompt

--- a/src/shell_hooks.h
+++ b/src/shell_hooks.h
@@ -5,7 +5,7 @@
 
 namespace envy::shell_hooks {
 
-inline constexpr int kShellHookVersion = 10;
+inline constexpr int kShellHookVersion = 11;
 
 // Parse _ENVY_HOOK_VERSION from the first 5 lines of a hook file.
 // Returns 0 if file is missing, unreadable, or has no valid stamp.


### PR DESCRIPTION
## What

The PowerShell shell hook froze its UTF-8 detection at source time. On Windows, PowerShell defaults to the OEM code page (e.g. 437), so unless the console was already UTF-8 *when the profile sourced the hook*, the raccoon prompt icon never appeared — and the failure was completely silent (`--` separator instead of an em-dash was the only tell).

## Changes

- **Per-prompt re-detection** — `_ENVY_UTF8`/`_ENVY_DASH` are recomputed on every prompt (cheap) instead of once at source time, so flipping the console encoding takes effect without re-sourcing.
- **One-time hint** — entering a project with the icon *wanted* (`ENVY_SHELL_NO_ICON` unset) but a non-UTF-8 console emits a single stderr nudge that names the fix. Gated on `ENVY_SHELL_NO_ICON` only — if the user opted out of the icon, they are never nudged about it.
- **Version bump** — `kShellHookVersion` 10 → 11 (single source of truth in `src/shell_hooks.h`; CMake derives the stamp) so installed hooks auto-refresh.
- **Docs** — Windows/PowerShell UTF-8 troubleshooting note in `docs/shell-integration.md`.
- **Tests** — two pwsh functional tests: hint shown when wanted on a non-UTF-8 console; hint suppressed under `ENVY_SHELL_NO_ICON=1`.

## Scope

PowerShell hook only. bash/zsh/fish are unchanged — their locales are virtually always UTF-8, so this failure mode doesn't bite there.

## Test

`./build.sh` + `python3.13 -m functional_tests` were **not** run in this session. Validation done: the hook parse-checks clean through the PowerShell parser; the new behaviors (one-time hint, opt-out suppression, live re-detection on encoding flip) were verified in isolated `pwsh` runs against a materialized hook; the modified test file byte-compiles under Python 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
